### PR TITLE
Refactor(ux): always show `Sharpness` and `Sharpness +1`

### DIFF
--- a/sass/_components.scss
+++ b/sass/_components.scss
@@ -461,15 +461,21 @@ $ranks: (
     text-decoration: none;
 
     .sharpness-container {
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
       position: relative;
-      margin-left: auto;
+      margin: 0 0 0 auto;
+      
+      @media screen and (max-width: 600px) {
+        margin: 1rem auto 0 0;
+      }
     }
 
     .sharpness {
       display: flex;
       height: 2.4rem;
       padding: 6px 8px;
-      margin-bottom: 4px;
       position: relative;
       margin-left: auto;
       width: 19.6rem;
@@ -483,7 +489,6 @@ $ranks: (
       display: flex;
       height: 2.4rem;
       padding: 6px 8px;
-      margin-top: 4px;
       position: relative;
       margin-left: auto;
       width: 19.6rem;

--- a/sass/_components.scss
+++ b/sass/_components.scss
@@ -460,7 +460,25 @@ $ranks: (
     color: white;
     text-decoration: none;
 
+    .sharpness-container {
+      position: relative;
+      margin-left: auto;
+    }
+
     .sharpness {
+      display: flex;
+      height: 2.4rem;
+      padding: 6px 8px;
+      position: relative;
+      margin-left: auto;
+      width: 19.6rem;
+
+      @media screen and (max-width: 600px) {
+        margin: 0 auto;
+      }
+    }
+
+    .sharpness-plus {
       display: flex;
       height: 2.4rem;
       padding: 6px 8px;
@@ -488,9 +506,19 @@ $ranks: (
       z-index: 10;
     }
 
-    .sharpness:focus-within::after,
-    .sharpness:hover::after {
+    .sharpness-plus::after {
+      content: '';
+      width: 100%;
+      height: 100%;
+      position: absolute;
+      top: 0;
+      left: 0;
       background-image: url("/images/sharpness-plus.png");
+      background-size: cover;
+      image-rendering: -webkit-optimize-contrast;
+      image-rendering: crisp-edges;
+      image-rendering: pixelated;
+      z-index: 10;
     }
 
     .hunter_type,
@@ -912,20 +940,20 @@ $sharpness-colors: (
     display: inline-block;
     height: 100%;
     z-index: 1;
+  }
 
-    &.sharp--plus {
-      display: none;
+  @each $value, $color in $sharpness-colors {
+    [class*=sharp-#{$value}] {
+      background-color: $color;
     }
   }
+}
 
-  &:focus-within span,
-  &:hover span {
-    display: none;
-  }
-
-  &:focus-within span.sharp--plus,
-  &:hover span.sharp--plus {
-    display: block;
+.sharpness-plus {
+  span {
+    display: inline-block;
+    height: 100%;
+    z-index: 1;
   }
 
   @each $value, $color in $sharpness-colors {

--- a/sass/_components.scss
+++ b/sass/_components.scss
@@ -469,6 +469,7 @@ $ranks: (
       display: flex;
       height: 2.4rem;
       padding: 6px 8px;
+      margin-bottom: 4px;
       position: relative;
       margin-left: auto;
       width: 19.6rem;
@@ -482,6 +483,7 @@ $ranks: (
       display: flex;
       height: 2.4rem;
       padding: 6px 8px;
+      margin-top: 4px;
       position: relative;
       margin-left: auto;
       width: 19.6rem;

--- a/templates/weapon.html
+++ b/templates/weapon.html
@@ -78,24 +78,27 @@
             >
               <img src="/images/{{ page.components[1] }}.png" alt="{{ page.extra.type | replace(from='-', to=' ') | capitalize }} weapon icon">
             </div>
+              <p id="weapon_name">
+                {{ page.extra.name }}
+              </p>
 
-            <p id="weapon_name">
-              {{ page.extra.name }}
-            </p>
-            
-            {% if page.extra.sharpness %}
-            <div tabindex="0" class="sharpness">
-              {% for sharp in page.extra.sharpness %}
-                <span class="sharp-{{ loop.index }}" style="width: {{ sharp | int * 4 }}px;"></span>
-              {% endfor %}
+              <div class="sharpness-container">
+              {% if page.extra.sharpness %}
+                <div title="Sharpness" tabindex="0" class="sharpness">
+                  {% for sharp in page.extra.sharpness %}
+                    <span class="sharp-{{ loop.index }}" style="width: {{ sharp | int * 4 }}px;"></span>
+                  {% endfor %}
+                </div>
+              {% endif %}
 
               {% if page.extra.sharpness_plus %}
+              <div title="Sharpness +1" tabindex="1" class="sharpness-plus">
                 {% for sharp in page.extra.sharpness_plus %}
                   <span class="sharp-{{ loop.index }} sharp--plus" style="width: {{ sharp | int * 4 }}px;"></span>
                 {% endfor %}
+              </div>
               {% endif %}
-            </div>
-            {% endif %}
+              </div>
           </div>
 
           <div class="weapon-card__details">


### PR DESCRIPTION
Hello !

First of all, thank you for this amazing website ! I've been using it a lot while playing lately.

I've got a lot of ideas to improve the UX on certain parts of the site but I've got below zero knowledge about HTML/CSS so I've tried my best to craft something that looks to work ok.

My goal was to split the sharpness bar since it was painful to always hover the bar to see the sharpness +1.

Thus this PR splits the bar in 2, and always show the Sharpness and Sharpness +1.

Screenshot:
<img width="2557" height="697" alt="sharpness-split" src="https://github.com/user-attachments/assets/e6ff4ad9-ffdc-420c-864b-72804ca5b21b" />

I've kept the little color change around the background image because I think it was neat. I've also added a small tooltip that appears when hovering the sharpness bar to tell you which one is `Sharpness` / `Sharpness +1`,

I don' t know if you accept PRs but I'll give it a shot.

Please don' t hesitate to double check the code as it's my first time with HTML/CSS.

Happy hunting !