### PR TITLE
Feat: add craftable information for weapons

### DIFF
--- a/content/blacksmith/bow/map.json
+++ b/content/blacksmith/bow/map.json
@@ -5,6 +5,7 @@
     "type": "bow",
     "name": "Hunter's Bow I",
     "rarity": 1,
+    "craftable": true,
     "children": [
       {
         "slug": "hunter-s-bow-ii",
@@ -17,6 +18,7 @@
             "type": "bow",
             "name": "Hunter's Bow III",
             "rarity": 3,
+            "craftable": true,
             "children": [
               {
                 "slug": "hunter-s-bow-iv",
@@ -29,6 +31,7 @@
                     "type": "bow",
                     "name": "Hunter's Power Bow I",
                     "rarity": 4,
+                    "craftable": true,
                     "children": [
                       {
                         "slug": "hunter-s-power-bow-ii",
@@ -54,6 +57,7 @@
                                 "name": "Icicle Bow I",
                                 "rarity": 9,
                                 "element": "ice",
+                                "craftable": true,
                                 "children": [
                                   {
                                     "slug": "icicle-bow-ii",
@@ -83,6 +87,7 @@
     "type": "bow",
     "name": "Wild Bow I",
     "rarity": 2,
+    "craftable": true,
     "children": [
       {
         "slug": "wild-bow-ii",
@@ -95,6 +100,7 @@
             "type": "bow",
             "name": "Wild Bow III",
             "rarity": 4,
+            "craftable": true,
             "children": [
               {
                 "slug": "wild-bow-iv",
@@ -107,6 +113,7 @@
                     "type": "bow",
                     "name": "Wild Power Bow I",
                     "rarity": 6,
+                    "craftable": true,
                     "children": [
                       {
                         "slug": "wild-power-bow-ii",
@@ -119,6 +126,7 @@
                             "type": "bow",
                             "name": "Jungle Bow I",
                             "rarity": 9,
+                            "craftable": true,
                             "children": [
                               {
                                 "slug": "jungle-bow-ii",
@@ -146,6 +154,7 @@
     "name": "Blango Fur Bow I",
     "rarity": 2,
     "element": "ice",
+    "craftable": true,
     "children": [
       {
         "slug": "blango-fur-bow-ii",
@@ -160,6 +169,7 @@
             "name": "Blango Fur Bow III",
             "rarity": 4,
             "element": "ice",
+            "craftable": true,
             "children": [
               {
                 "slug": "blango-fur-bow-iv",
@@ -198,6 +208,7 @@
     "name": "Kut-Ku Stave I",
     "rarity": 2,
     "element": "fire",
+    "craftable": true,
     "children": [
       {
         "slug": "kut-ku-stave-ii",
@@ -219,6 +230,7 @@
                 "name": "Blue Kut-Ku Stave I",
                 "rarity": 7,
                 "element": "fire",
+                "craftable": true,
                 "children": [
                   {
                     "slug": "blue-kut-ku-stave-ii",
@@ -241,6 +253,7 @@
                     "type": "bow",
                     "name": "Wolf Bow",
                     "rarity": 9,
+                    "craftable": true,
                     "children": [
                       {
                         "slug": "crow-bow",
@@ -264,6 +277,7 @@
     "name": "Daimyo's Warbow I",
     "rarity": 3,
     "element": "water",
+    "craftable": true,
     "children": [
       {
         "slug": "daimyo-s-warbow-ii",
@@ -285,6 +299,7 @@
                 "name": "Daimyo's Warbow IV",
                 "rarity": 6,
                 "element": "water",
+                "craftable": true,
                 "children": [
                   {
                     "slug": "great-purple-emperor-i",
@@ -292,6 +307,7 @@
                     "name": "Great Purple Emperor I",
                     "rarity": 9,
                     "element": "water",
+                    "craftable": true,
                     "children": [
                       {
                         "slug": "great-purple-emperor-ii",
@@ -316,6 +332,7 @@
     "name": "Sonic Bow I",
     "rarity": 3,
     "element": "thunder",
+    "craftable": true,
     "children": [
       {
         "slug": "sonic-bow-ii",
@@ -330,6 +347,7 @@
             "name": "Sonic Bow III",
             "rarity": 6,
             "element": "thunder",
+            "craftable": true,
             "children": [
               {
                 "slug": "sonic-bow-iv",
@@ -349,6 +367,7 @@
     "type": "bow",
     "name": "Blue Blade Bow I",
     "rarity": 4,
+    "craftable": true,
     "children": [
       {
         "slug": "blue-blade-bow-ii",
@@ -361,6 +380,7 @@
             "type": "bow",
             "name": "Blue Blade Bow III",
             "rarity": 9,
+            "craftable": true,
             "children": [
               {
                 "slug": "showroom-model",
@@ -396,6 +416,7 @@
     "name": "Queen Blaster I",
     "rarity": 4,
     "element": "poison",
+    "craftable": true,
     "children": [
       {
         "slug": "queen-blaster-ii",
@@ -410,6 +431,7 @@
             "name": "Queen Blaster III",
             "rarity": 6,
             "element": "poison",
+            "craftable": true,
             "children": [
               {
                 "slug": "queen-blaster-iv",
@@ -434,6 +456,7 @@
             "type": "bow",
             "name": "Heartshot Bow I",
             "rarity": 7,
+            "craftable": true,
             "children": [
               {
                 "slug": "heartshot-bow-ii",
@@ -461,6 +484,7 @@
     "name": "Prominence Bow I",
     "rarity": 4,
     "element": "fire",
+    "craftable": true,
     "children": [
       {
         "slug": "prominence-bow-ii",
@@ -482,6 +506,7 @@
                 "name": "Prominence Bow IV",
                 "rarity": 9,
                 "element": "fire",
+                "craftable": true,
                 "children": [
                   {
                     "slug": "prominence-bow-v",
@@ -503,6 +528,7 @@
     "type": "bow",
     "name": "Tiger Arrow I",
     "rarity": 4,
+    "craftable": true,
     "children": [
       {
         "slug": "tiger-arrow-ii",
@@ -515,6 +541,7 @@
             "type": "bow",
             "name": "Tigrex Whisker",
             "rarity": 6,
+            "craftable": true,
             "children": [
               {
                 "slug": "tigrex-whisker-plus",
@@ -529,12 +556,14 @@
             "type": "bow",
             "name": "Hidden Bow",
             "rarity": 7,
+            "craftable": true,
             "children": [
               {
                 "slug": "midnight-bow",
                 "type": "bow",
                 "name": "Midnight Bow",
-                "rarity": 10
+                "rarity": 10,
+                "craftable": true
               }
             ]
           }
@@ -548,6 +577,7 @@
     "name": "Black Bow I",
     "rarity": 5,
     "element": "dragon",
+    "craftable": true,
     "children": [
       {
         "slug": "black-bow-ii",
@@ -561,6 +591,7 @@
             "type": "bow",
             "name": "Exterminator Bow I",
             "rarity": 8,
+            "craftable": true,
             "children": [
               {
                 "slug": "exterminator-bow-ii",
@@ -576,6 +607,7 @@
             "name": "Glorious Victory I",
             "rarity": 8,
             "element": "dragon",
+            "craftable": true,
             "children": [
               {
                 "slug": "glorious-victory-ii",
@@ -596,6 +628,7 @@
     "name": "Dragon Bow Earth",
     "rarity": 5,
     "element": "dragon",
+    "craftable": true,
     "children": [
       {
         "slug": "dragon-bow-mountain",
@@ -621,6 +654,7 @@
     "name": "Dragon Bow Halo",
     "rarity": 5,
     "element": "thunder",
+    "craftable": true,
     "children": [
       {
         "slug": "dragon-bow-solar",
@@ -634,7 +668,8 @@
             "type": "bow",
             "name": "Ancient Dragonwood Bow",
             "rarity": 10,
-            "element": "thunder"
+            "element": "thunder",
+            "craftable": true
           }
         ]
       }
@@ -646,6 +681,7 @@
     "name": "Defect Swordfish Bow",
     "rarity": 5,
     "element": "paralysis",
+    "craftable": true,
     "children": [
       {
         "slug": "whole-swordfish-bow",
@@ -671,6 +707,7 @@
     "name": "Wing Bow I",
     "rarity": 6,
     "element": "sleep",
+    "craftable": true,
     "children": [
       {
         "slug": "wing-bow-ii",
@@ -685,6 +722,7 @@
             "name": "Wing Bow III",
             "rarity": 9,
             "element": "sleep",
+            "craftable": true,
             "children": [
               {
                 "slug": "wing-bow-iv",
@@ -704,6 +742,7 @@
     "type": "bow",
     "name": "Diablos Horn Bow I",
     "rarity": 6,
+    "craftable": true,
     "children": [
       {
         "slug": "diablos-horn-bow-ii",
@@ -716,6 +755,7 @@
             "type": "bow",
             "name": "Gale Horn Bow",
             "rarity": 9,
+            "craftable": true,
             "children": [
               {
                 "slug": "diabloskinghornbow",
@@ -735,6 +775,7 @@
     "name": "Courageous Hope",
     "rarity": 8,
     "element": "fire",
+    "craftable": true,
     "children": [
       {
         "slug": "courageous-wish",
@@ -760,6 +801,7 @@
     "name": "Dragonhead Harp I",
     "rarity": 8,
     "element": "water",
+    "craftable": true,
     "children": [
       {
         "slug": "dragonhead-harp-ii",
@@ -785,6 +827,7 @@
     "name": "Akantor Bow",
     "rarity": 8,
     "element": "dragon",
+    "craftable": true,
     "children": [
       {
         "slug": "akantor-chaos-bow",
@@ -801,6 +844,7 @@
     "name": "Khezu Bow I",
     "rarity": 9,
     "element": "thunder",
+    "craftable": true,
     "children": [
       {
         "slug": "khezu-bow-ii",
@@ -817,6 +861,7 @@
     "name": "Icy Steel Bow",
     "rarity": 10,
     "element": "ice",
+    "craftable": true,
     "children": [
       {
         "slug": "daora-s-sagittarii",
@@ -833,6 +878,7 @@
     "name": "Beast Thunderbow",
     "rarity": 10,
     "element": "thunder",
+    "craftable": true,
     "children": [
       {
         "slug": "beastkingthunderbow",
@@ -848,80 +894,92 @@
     "type": "bow",
     "name": "dummy (Diasorute Arrow)",
     "rarity": 9,
-    "element": "fire"
+    "element": "fire",
+    "craftable": true
   },
   {
     "slug": "ukanlos-bow",
     "type": "bow",
     "name": "Ukanlos Bow",
     "rarity": 10,
-    "element": "ice"
+    "element": "ice",
+    "craftable": true
   },
   {
     "slug": "hunter-s-bow-g",
     "type": "bow",
     "name": "Hunter's Bow G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "wild-bow-g",
     "type": "bow",
     "name": "Wild Bow G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "wild-power-bow-g",
     "type": "bow",
     "name": "Wild Power Bow G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "blango-fur-bow-g",
     "type": "bow",
     "name": "Blango Fur Bow G",
     "rarity": 9,
-    "element": "ice"
+    "element": "ice",
+    "craftable": true
   },
   {
     "slug": "kut-ku-stave-g",
     "type": "bow",
     "name": "Kut-Ku Stave G",
     "rarity": 9,
-    "element": "fire"
+    "element": "fire",
+    "craftable": true
   },
   {
     "slug": "daimyo-s-warbow-g",
     "type": "bow",
     "name": "Daimyo's Warbow G",
     "rarity": 9,
-    "element": "water"
+    "element": "water",
+    "craftable": true
   },
   {
     "slug": "sonic-bow-g",
     "type": "bow",
     "name": "Sonic Bow G",
     "rarity": 9,
-    "element": "thunder"
+    "element": "thunder",
+    "craftable": true
   },
   {
     "slug": "diablos-horn-bow-g",
     "type": "bow",
     "name": "Diablos Horn Bow G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "dragon-bow-solar-g",
     "type": "bow",
     "name": "Dragon Bow Solar G",
     "rarity": 10,
-    "element": "thunder"
+    "element": "thunder",
+    "craftable": true
   },
   {
     "slug": "black-bow-g",
     "type": "bow",
     "name": "Black Bow G",
     "rarity": 10,
-    "element": "dragon"
+    "element": "dragon",
+    "craftable": true
   }
 ]
 }

--- a/content/blacksmith/dual-blades/map.json
+++ b/content/blacksmith/dual-blades/map.json
@@ -5,6 +5,7 @@
     "type": "dual-blades",
     "name": "Bone Scythe",
     "rarity": 1,
+    "craftable": true,
     "children": [
       {
         "slug": "bone-scythe-plus",
@@ -23,6 +24,7 @@
                 "type": "dual-blades",
                 "name": "Bladed Edge",
                 "rarity": 4,
+                "craftable": true,
                 "children": [
                   {
                     "slug": "bladed-edge-plus",
@@ -41,6 +43,7 @@
                             "type": "dual-blades",
                             "name": "Carmine Edge",
                             "rarity": 9,
+                            "craftable": true,
                             "children": [
                               {
                                 "slug": "red-rippers",
@@ -58,6 +61,7 @@
                         "name": "Dual Carapace",
                         "rarity": 7,
                         "element": "water",
+                        "craftable": true,
                         "children": []
                       }
                     ]
@@ -86,6 +90,7 @@
                 "name": "Twin Kut-Ku",
                 "rarity": 2,
                 "element": "fire",
+                "craftable": true,
                 "children": [
                   {
                     "slug": "pink-maracas",
@@ -110,6 +115,7 @@
                                 "type": "dual-blades",
                                 "name": "Jungle Maracas",
                                 "rarity": 9,
+                                "craftable": true,
                                 "children": [
                                   {
                                     "slug": "evergreen",
@@ -146,6 +152,7 @@
                     "type": "dual-blades",
                     "name": "Raven Tessen",
                     "rarity": 5,
+                    "craftable": true,
                     "children": [
                       {
                         "slug": "wolf-tessen",
@@ -182,6 +189,7 @@
         "type": "dual-blades",
         "name": "Bone Scythe",
         "rarity": 1,
+        "craftable": true,
         "children": [
           {
             "slug": "bone-scythe-plus",
@@ -200,6 +208,7 @@
                     "type": "dual-blades",
                     "name": "Bladed Edge",
                     "rarity": 4,
+                    "craftable": true,
                     "children": [
                       {
                         "slug": "bladed-edge-plus",
@@ -218,6 +227,7 @@
                                 "type": "dual-blades",
                                 "name": "Carmine Edge",
                                 "rarity": 9,
+                                "craftable": true,
                                 "children": [
                                   {
                                     "slug": "red-rippers",
@@ -235,6 +245,7 @@
                             "name": "Dual Carapace",
                             "rarity": 7,
                             "element": "water",
+                            "craftable": true,
                             "children": []
                           }
                         ]
@@ -263,6 +274,7 @@
                     "name": "Twin Kut-Ku",
                     "rarity": 2,
                     "element": "fire",
+                    "craftable": true,
                     "children": [
                       {
                         "slug": "pink-maracas",
@@ -287,6 +299,7 @@
                                     "type": "dual-blades",
                                     "name": "Jungle Maracas",
                                     "rarity": 9,
+                                    "craftable": true,
                                     "children": [
                                       {
                                         "slug": "evergreen",
@@ -323,6 +336,7 @@
                         "type": "dual-blades",
                         "name": "Raven Tessen",
                         "rarity": 5,
+                        "craftable": true,
                         "children": [
                           {
                             "slug": "wolf-tessen",
@@ -355,12 +369,14 @@
     "type": "sword-and-shield",
     "name": "Hunter's Dagger+",
     "rarity": 1,
+    "craftable": true,
     "children": [
       {
         "slug": "twin-dagger",
         "type": "dual-blades",
         "name": "Twin Dagger",
         "rarity": 1,
+        "craftable": true,
         "children": [
           {
             "slug": "twin-dagger-plus",
@@ -373,6 +389,7 @@
                 "type": "dual-blades",
                 "name": "Glutton's Set",
                 "rarity": 2,
+                "craftable": true,
                 "children": [
                   {
                     "slug": "spatula-set",
@@ -438,6 +455,7 @@
                     "name": "Order Rapier",
                     "rarity": 3,
                     "element": "water",
+                    "craftable": true,
                     "children": [
                       {
                         "slug": "holy-saber",
@@ -476,6 +494,7 @@
                             "type": "sword-and-shield",
                             "name": "Ninja Sword",
                             "rarity": 5,
+                            "craftable": true,
                             "children": []
                           }
                         ]
@@ -501,6 +520,7 @@
     "type": "sword-and-shield",
     "name": "Hunter's Dagger",
     "rarity": 1,
+    "craftable": true,
     "children": [
       {
         "slug": "giaprey-claws",
@@ -508,6 +528,7 @@
         "name": "Giaprey Claws",
         "rarity": 2,
         "element": "ice",
+        "craftable": true,
         "children": [
           {
             "slug": "giaprey-claws-plus",
@@ -534,6 +555,7 @@
                     "type": "dual-blades",
                     "name": "Velociprey Claws+",
                     "rarity": 4,
+                    "craftable": true,
                     "children": [
                       {
                         "slug": "hi-velociprey-claws",
@@ -551,6 +573,7 @@
                 "name": "Snow Venom",
                 "rarity": 4,
                 "element": "ice",
+                "craftable": true,
                 "children": [
                   {
                     "slug": "snow-venom-plus",
@@ -581,6 +604,7 @@
     "type": "sword-and-shield",
     "name": "Velocidrome Bite",
     "rarity": 2,
+    "craftable": true,
     "children": [
       {
         "slug": "velociprey-claws",
@@ -593,6 +617,7 @@
             "type": "dual-blades",
             "name": "Velociprey Claws+",
             "rarity": 4,
+            "craftable": true,
             "children": [
               {
                 "slug": "hi-velociprey-claws",
@@ -612,6 +637,7 @@
     "name": "Red Saber",
     "rarity": 3,
     "element": "fire",
+    "craftable": true,
     "children": [
       {
         "slug": "twin-flames",
@@ -663,6 +689,7 @@
     "type": "dual-blades",
     "name": "dummy (Dual Tessen \"Gavas\")",
     "rarity": 4,
+    "craftable": true,
     "children": [
       {
         "slug": "dummy-dualtessen-100gavas",
@@ -686,6 +713,7 @@
     "type": "sword-and-shield",
     "name": "Hero's Blade Replica",
     "rarity": 4,
+    "craftable": true,
     "children": [
       {
         "slug": "legendary-replica",
@@ -701,6 +729,7 @@
     "name": "Felyne and Melynx",
     "rarity": 4,
     "element": "paralysis",
+    "craftable": true,
     "children": [
       {
         "slug": "felyne-and-melynx-plus",
@@ -716,6 +745,7 @@
     "type": "sword-and-shield",
     "name": "Studded Club",
     "rarity": 4,
+    "craftable": true,
     "children": [
       {
         "slug": "dual-diablo",
@@ -796,6 +826,7 @@
         "name": "Freezing Daggers",
         "rarity": 4,
         "element": "ice",
+        "craftable": true,
         "children": [
           {
             "slug": "icicle-daggers",
@@ -830,6 +861,7 @@
         "name": "Dual Battleaxe",
         "rarity": 6,
         "element": "poison",
+        "craftable": true,
         "children": [
           {
             "slug": "dual-battleaxe-plus",
@@ -864,6 +896,7 @@
         "name": "Twin Nails",
         "rarity": 5,
         "element": "ice",
+        "craftable": true,
         "children": [
           {
             "slug": "twin-nails-plus",
@@ -891,6 +924,7 @@
     "name": "Black Sword",
     "rarity": 5,
     "element": "dragon",
+    "craftable": true,
     "children": [
       {
         "slug": "double-dragon",
@@ -956,6 +990,7 @@
             "name": "Festive Fall Typhoon",
             "rarity": 8,
             "element": "thunder",
+            "craftable": true,
             "children": [
               {
                 "slug": "festiverustlingrain",
@@ -976,6 +1011,7 @@
     "name": "Black Twin Daggers",
     "rarity": 5,
     "element": "dragon",
+    "craftable": true,
     "children": [
       {
         "slug": "fatalis-dual-blades",
@@ -1017,6 +1053,7 @@
     "name": "Flaming Pair",
     "rarity": 5,
     "element": "dragon",
+    "craftable": true,
     "children": [
       {
         "slug": "crimson-lotus-blades",
@@ -1049,6 +1086,7 @@
         "name": "Blue Ogre Sword",
         "rarity": 8,
         "element": "dragon",
+        "craftable": true,
         "children": []
       }
     ]
@@ -1058,6 +1096,7 @@
     "type": "dual-blades",
     "name": "Rex Slicers",
     "rarity": 5,
+    "craftable": true,
     "children": [
       {
         "slug": "tigrex-claws",
@@ -1078,12 +1117,14 @@
         "type": "dual-blades",
         "name": "Hidden Ones",
         "rarity": 7,
+        "craftable": true,
         "children": [
           {
             "slug": "ebony-wings",
             "type": "dual-blades",
             "name": "Ebony Wings",
-            "rarity": 10
+            "rarity": 10,
+            "craftable": true
           }
         ]
       }
@@ -1094,6 +1135,7 @@
     "type": "dual-blades",
     "name": "Worn Blades",
     "rarity": 6,
+    "craftable": true,
     "children": [
       {
         "slug": "weathered-blades",
@@ -1175,12 +1217,14 @@
     "type": "sword-and-shield",
     "name": "Odyssey",
     "rarity": 6,
+    "craftable": true,
     "children": [
       {
         "slug": "hurricane",
         "type": "dual-blades",
         "name": "Hurricane",
         "rarity": 6,
+        "craftable": true,
         "children": [
           {
             "slug": "cyclone",
@@ -1193,6 +1237,7 @@
                 "type": "dual-blades",
                 "name": "Tornado Tomahawks",
                 "rarity": 9,
+                "craftable": true,
                 "children": [
                   {
                     "slug": "typhoon",
@@ -1206,6 +1251,7 @@
                     "name": "Firestorm",
                     "rarity": 9,
                     "element": "fire",
+                    "craftable": true,
                     "children": [
                       {
                         "slug": "volcanic-storm",
@@ -1228,6 +1274,7 @@
         "name": "Prototype Saw-Slicer",
         "rarity": 6,
         "element": "thunder",
+        "craftable": true,
         "children": [
           {
             "slug": "sanctioned-blades",
@@ -1263,6 +1310,7 @@
     "type": "dual-blades",
     "name": "Akantor Blades",
     "rarity": 8,
+    "craftable": true,
     "children": [
       {
         "slug": "akantor-shadow-claws",
@@ -1277,156 +1325,180 @@
     "type": "dual-blades",
     "name": "UkanlosRuinerBlades",
     "rarity": 10,
-    "element": "ice"
+    "element": "ice",
+    "craftable": true
   },
   {
     "slug": "dummy-amezari-claws",
     "type": "dual-blades",
     "name": "dummy (Amezari Claws)",
     "rarity": 9,
-    "element": "water"
+    "element": "water",
+    "craftable": true
   },
   {
     "slug": "bone-scythe-g",
     "type": "dual-blades",
     "name": "Bone Scythe G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "worn-blades-g",
     "type": "dual-blades",
     "name": "Worn Blades G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "velociprey-claws-g",
     "type": "dual-blades",
     "name": "Velociprey Claws G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "white-death-g",
     "type": "dual-blades",
     "name": "White Death G",
     "rarity": 9,
-    "element": "ice"
+    "element": "ice",
+    "craftable": true
   },
   {
     "slug": "dual-tomahawk-g",
     "type": "dual-blades",
     "name": "Dual Tomahawk G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "insector-g",
     "type": "dual-blades",
     "name": "Insector G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "glutton-s-set-g",
     "type": "dual-blades",
     "name": "Glutton's Set G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "spatula-set-g",
     "type": "dual-blades",
     "name": "Spatula Set G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "holy-saber-g",
     "type": "dual-blades",
     "name": "Holy Saber G",
     "rarity": 9,
-    "element": "water"
+    "element": "water",
+    "craftable": true
   },
   {
     "slug": "cyclone-g",
     "type": "dual-blades",
     "name": "Cyclone G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "dual-kut-ku-g",
     "type": "dual-blades",
     "name": "Dual Kut-Ku G",
     "rarity": 9,
-    "element": "fire"
+    "element": "fire",
+    "craftable": true
   },
   {
     "slug": "funky-maracas-g",
     "type": "dual-blades",
     "name": "Funky Maracas G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "prototypesaw-slicr-g",
     "type": "dual-blades",
     "name": "PrototypeSaw-Slicr G",
     "rarity": 9,
-    "element": "thunder"
+    "element": "thunder",
+    "craftable": true
   },
   {
     "slug": "cutlass-g",
     "type": "dual-blades",
     "name": "Cutlass G",
     "rarity": 9,
-    "element": "water"
+    "element": "water",
+    "craftable": true
   },
   {
     "slug": "limb-cutter-g",
     "type": "dual-blades",
     "name": "Limb Cutter G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "dual-diablo-g",
     "type": "dual-blades",
     "name": "Dual Diablo G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "silhouette-sabers-g",
     "type": "dual-blades",
     "name": "Silhouette Sabers G",
     "rarity": 10,
-    "element": "ice"
+    "element": "ice",
+    "craftable": true
   },
   {
     "slug": "gradios-ultimus-g",
     "type": "dual-blades",
     "name": "Gradios Ultimus G",
     "rarity": 10,
-    "element": "fire"
+    "element": "fire",
+    "craftable": true
   },
   {
     "slug": "kirin-bolts-g",
     "type": "dual-blades",
     "name": "Kirin Bolts G",
     "rarity": 10,
-    "element": "thunder"
+    "element": "thunder",
+    "craftable": true
   },
   {
     "slug": "crimsonlotusblades-g",
     "type": "dual-blades",
     "name": "CrimsonLotusBlades G",
     "rarity": 10,
-    "element": "dragon"
+    "element": "dragon",
+    "craftable": true
   },
   {
     "slug": "dualdragonultimus-g",
     "type": "dual-blades",
     "name": "DualDragonUltimus G",
     "rarity": 10,
-    "element": "dragon"
+    "element": "dragon",
+    "craftable": true
   },
   {
     "slug": "legendary-blades-g",
     "type": "dual-blades",
     "name": "Legendary Blades G",
-    "rarity": 10
+    "rarity": 10,
+    "craftable": true
   }
 ]
 }

--- a/content/blacksmith/great-sword/map.json
+++ b/content/blacksmith/great-sword/map.json
@@ -5,12 +5,14 @@
     "type": "great-sword",
     "name": "Buster Sword",
     "rarity": 1,
+    "craftable": true,
     "children": [
       {
         "slug": "buster-sword-plus",
         "type": "great-sword",
         "name": "Buster Sword+",
         "rarity": 1,
+        "craftable": true,
         "children": [
           {
             "slug": "buster-blade",
@@ -23,12 +25,14 @@
                 "type": "great-sword",
                 "name": "Ravager Blade",
                 "rarity": 2,
+                "craftable": true,
                 "children": [
                   {
                     "slug": "ravager-blade-plus",
                     "type": "great-sword",
                     "name": "Ravager Blade+",
                     "rarity": 3,
+                    "craftable": true,
                     "children": [
                       {
                         "slug": "tactical-blade",
@@ -63,6 +67,7 @@
                             "type": "great-sword",
                             "name": "Carbalite Sword",
                             "rarity": 6,
+                            "craftable": true,
                             "children": [
                               {
                                 "slug": "carbalite-sword-plus",
@@ -90,6 +95,7 @@
                                     "name": "Demon Halberd",
                                     "rarity": 7,
                                     "element": "thunder",
+                                    "craftable": true,
                                     "children": []
                                   },
                                   {
@@ -97,6 +103,7 @@
                                     "type": "great-sword",
                                     "name": "Decider",
                                     "rarity": 9,
+                                    "craftable": true,
                                     "children": [
                                       {
                                         "slug": "punisher",
@@ -110,6 +117,7 @@
                                         "name": "Igneous Blade",
                                         "rarity": 9,
                                         "element": "fire",
+                                        "craftable": true,
                                         "children": [
                                           {
                                             "slug": "igneous-sword",
@@ -124,6 +132,7 @@
                                             "name": "Liquid Fire Blade",
                                             "rarity": 9,
                                             "element": "fire",
+                                            "craftable": true,
                                             "children": []
                                           }
                                         ]
@@ -134,6 +143,7 @@
                                         "name": "Liquid Fire Blade",
                                         "rarity": 9,
                                         "element": "fire",
+                                        "craftable": true,
                                         "children": []
                                       }
                                     ]
@@ -145,6 +155,7 @@
                                 "type": "great-sword",
                                 "name": "Bronze Coin",
                                 "rarity": 5,
+                                "craftable": true,
                                 "children": [
                                   {
                                     "slug": "gaoren-coin",
@@ -167,6 +178,7 @@
                                 "type": "long-sword",
                                 "name": "Guardian Sword",
                                 "rarity": 6,
+                                "craftable": true,
                                 "children": []
                               }
                             ]
@@ -181,6 +193,7 @@
                     "name": "Khezu Shock Sword",
                     "rarity": 3,
                     "element": "thunder",
+                    "craftable": true,
                     "children": [
                       {
                         "slug": "khezu-shock-blade",
@@ -238,6 +251,7 @@
                             "name": "Cat of Venus",
                             "rarity": 9,
                             "element": "paralysis",
+                            "craftable": true,
                             "children": [
                               {
                                 "slug": "cat-of-gold",
@@ -274,6 +288,7 @@
                     "name": "Barbaroi Blade",
                     "rarity": 3,
                     "element": "fire",
+                    "craftable": true,
                     "children": [
                       {
                         "slug": "crimson-goat",
@@ -289,6 +304,7 @@
                     "type": "great-sword",
                     "name": "Halberd",
                     "rarity": 4,
+                    "craftable": true,
                     "children": [
                       {
                         "slug": "judgment",
@@ -307,6 +323,7 @@
             "type": "long-sword",
             "name": "Iron Katana",
             "rarity": 1,
+            "craftable": true,
             "children": []
           }
         ]
@@ -317,6 +334,7 @@
         "name": "White Serpentblade",
         "rarity": 2,
         "element": "ice",
+        "craftable": true,
         "children": [
           {
             "slug": "silver-serpentblade",
@@ -366,6 +384,7 @@
         "name": "Blango Destroyer",
         "rarity": 2,
         "element": "ice",
+        "craftable": true,
         "children": []
       }
     ]
@@ -375,6 +394,7 @@
     "type": "great-sword",
     "name": "Bone Blade",
     "rarity": 1,
+    "craftable": true,
     "children": [
       {
         "slug": "bone-blade-plus",
@@ -387,12 +407,14 @@
             "type": "great-sword",
             "name": "Bone Slasher",
             "rarity": 1,
+            "craftable": true,
             "children": [
               {
                 "slug": "golem-blade",
                 "type": "great-sword",
                 "name": "Golem Blade",
                 "rarity": 2,
+                "craftable": true,
                 "children": [
                   {
                     "slug": "golem-blade-plus",
@@ -405,6 +427,7 @@
                         "type": "great-sword",
                         "name": "Valkyrie Blade",
                         "rarity": 3,
+                        "craftable": true,
                         "children": [
                           {
                             "slug": "sieglinde",
@@ -501,6 +524,7 @@
                         "type": "great-sword",
                         "name": "Executioner",
                         "rarity": 4,
+                        "craftable": true,
                         "children": [
                           {
                             "slug": "executioner-plus",
@@ -521,6 +545,7 @@
                             "type": "great-sword",
                             "name": "Agito",
                             "rarity": 6,
+                            "craftable": true,
                             "children": [
                               {
                                 "slug": "wyvern-agito",
@@ -540,6 +565,7 @@
                                     "name": "Demon Rod",
                                     "rarity": 7,
                                     "element": "thunder",
+                                    "craftable": true,
                                     "children": [
                                       {
                                         "slug": "great-demon-rod",
@@ -576,6 +602,7 @@
                             "name": "Kirin Thundersword",
                             "rarity": 5,
                             "element": "thunder",
+                            "craftable": true,
                             "children": [
                               {
                                 "slug": "king-thundersword",
@@ -629,6 +656,7 @@
                 "name": "Finblade",
                 "rarity": 2,
                 "element": "water",
+                "craftable": true,
                 "children": [
                   {
                     "slug": "plesioth-watersword",
@@ -699,6 +727,7 @@
                             "name": "Pickaxe Blade",
                             "rarity": 6,
                             "element": "sleep",
+                            "craftable": true,
                             "children": [
                               {
                                 "slug": "pickaxe-blade-plus",
@@ -706,6 +735,7 @@
                                 "name": "Pickaxe Blade+",
                                 "rarity": 9,
                                 "element": "sleep",
+                                "craftable": true,
                                 "children": [
                                   {
                                     "slug": "sleep-sword-zantoma",
@@ -724,6 +754,7 @@
                             "name": "Slaughter",
                             "rarity": 6,
                             "element": "poison",
+                            "craftable": true,
                             "children": [
                               {
                                 "slug": "slaughter-plus",
@@ -752,6 +783,7 @@
                     "type": "great-sword",
                     "name": "Sentoryu Raven",
                     "rarity": 5,
+                    "craftable": true,
                     "children": [
                       {
                         "slug": "sentoryu-wolf",
@@ -785,6 +817,7 @@
                 "name": "Red Wing",
                 "rarity": 3,
                 "element": "fire",
+                "craftable": true,
                 "children": [
                   {
                     "slug": "rathalos-firesword",
@@ -818,6 +851,7 @@
             "type": "great-sword",
             "name": "Red Stripe",
             "rarity": 2,
+            "craftable": true,
             "children": [
               {
                 "slug": "red-pincer",
@@ -836,6 +870,7 @@
                         "type": "long-sword",
                         "name": "Crab Cutter",
                         "rarity": 6,
+                        "craftable": true,
                         "children": []
                       },
                       {
@@ -856,6 +891,7 @@
                             "type": "great-sword",
                             "name": "Carmine Blade",
                             "rarity": 9,
+                            "craftable": true,
                             "children": [
                               {
                                 "slug": "killer-s-carver",
@@ -870,6 +906,7 @@
                             "type": "great-sword",
                             "name": "Violet Pincer",
                             "rarity": 9,
+                            "craftable": true,
                             "children": [
                               {
                                 "slug": "grand-pincer",
@@ -915,6 +952,7 @@
                             "type": "great-sword",
                             "name": "Carmine Blade",
                             "rarity": 9,
+                            "craftable": true,
                             "children": [
                               {
                                 "slug": "killer-s-carver",
@@ -929,6 +967,7 @@
                             "type": "great-sword",
                             "name": "Violet Pincer",
                             "rarity": 9,
+                            "craftable": true,
                             "children": [
                               {
                                 "slug": "grand-pincer",
@@ -951,6 +990,7 @@
             "type": "long-sword",
             "name": "Bone Katana \"Wolf\"",
             "rarity": 1,
+            "craftable": true,
             "children": []
           }
         ]
@@ -962,6 +1002,7 @@
     "type": "great-sword",
     "name": "Rusted Great Sword",
     "rarity": 1,
+    "craftable": true,
     "children": [
       {
         "slug": "tarnished-great-swd",
@@ -1012,6 +1053,7 @@
                     "name": "Icesteel Blade",
                     "rarity": 8,
                     "element": "ice",
+                    "craftable": true,
                     "children": []
                   }
                 ]
@@ -1028,6 +1070,7 @@
     "name": "Frozen Tuna",
     "rarity": 3,
     "element": "ice",
+    "craftable": true,
     "children": [
       {
         "slug": "crystallized-tuna",
@@ -1043,6 +1086,7 @@
     "type": "great-sword",
     "name": "Black Belt Blade",
     "rarity": 4,
+    "craftable": true,
     "children": [
       {
         "slug": "expert-blade",
@@ -1065,6 +1109,7 @@
     "type": "great-sword",
     "name": "Tiger Agito",
     "rarity": 5,
+    "craftable": true,
     "children": [
       {
         "slug": "tigrex-great-sword",
@@ -1085,12 +1130,14 @@
         "type": "great-sword",
         "name": "Hidden Blaze",
         "rarity": 7,
+        "craftable": true,
         "children": [
           {
             "slug": "darkness-darkblade",
             "type": "great-sword",
             "name": "Darkness Darkblade",
-            "rarity": 10
+            "rarity": 10,
+            "craftable": true
           }
         ]
       }
@@ -1102,6 +1149,7 @@
     "name": "Dragonslayer",
     "rarity": 5,
     "element": "dragon",
+    "craftable": true,
     "children": [
       {
         "slug": "eternal-annihilator",
@@ -1136,6 +1184,7 @@
     "name": "Black Blade",
     "rarity": 5,
     "element": "dragon",
+    "craftable": true,
     "children": [
       {
         "slug": "fatalis-blade",
@@ -1176,6 +1225,7 @@
     "type": "great-sword",
     "name": "Worn Great Sword",
     "rarity": 6,
+    "craftable": true,
     "children": [
       {
         "slug": "weathered-grt-sword",
@@ -1239,6 +1289,7 @@
         "type": "great-sword",
         "name": "Violet Pincer",
         "rarity": 9,
+        "craftable": true,
         "children": [
           {
             "slug": "grand-pincer",
@@ -1255,6 +1306,7 @@
     "type": "great-sword",
     "name": "Akantor Broadsword",
     "rarity": 8,
+    "craftable": true,
     "children": [
       {
         "slug": "akantor-broadsword-plus",
@@ -1268,244 +1320,282 @@
     "slug": "dummy-roaringdecisionsword",
     "type": "great-sword",
     "name": "dummy (RoaringDecisionSword)",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "g-blade",
     "type": "great-sword",
     "name": "G Blade",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "ukanlos-destructor",
     "type": "great-sword",
     "name": "Ukanlos Destructor",
     "rarity": 10,
-    "element": "ice"
+    "element": "ice",
+    "craftable": true
   },
   {
     "slug": "buster-blade-g",
     "type": "great-sword",
     "name": "Buster Blade G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "bone-blade-g",
     "type": "great-sword",
     "name": "Bone Blade G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "tarnishdgreatswd-g",
     "type": "great-sword",
     "name": "TarnishdGreatSwd G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "ravager-blade-g",
     "type": "great-sword",
     "name": "Ravager Blade G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "golem-blade-g",
     "type": "great-sword",
     "name": "Golem Blade G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "sentinel-g",
     "type": "great-sword",
     "name": "Sentinel G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "red-stripe-g",
     "type": "great-sword",
     "name": "Red Stripe G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "goldnserpentblade-g",
     "type": "great-sword",
     "name": "GoldnSerpentblade G",
     "rarity": 9,
-    "element": "ice"
+    "element": "ice",
+    "craftable": true
   },
   {
     "slug": "great-serpentblade-g",
     "type": "great-sword",
     "name": "Great Serpentblade G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "cat-s-soul-g",
     "type": "great-sword",
     "name": "Cat's Soul G",
     "rarity": 9,
-    "element": "paralysis"
+    "element": "paralysis",
+    "craftable": true
   },
   {
     "slug": "poisnserpentblade-g",
     "type": "great-sword",
     "name": "PoisnSerpentblade G",
     "rarity": 9,
-    "element": "poison"
+    "element": "poison",
+    "craftable": true
   },
   {
     "slug": "decapitator-g",
     "type": "great-sword",
     "name": "Decapitator G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "great-pincer-g",
     "type": "great-sword",
     "name": "Great Pincer G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "executioner-g",
     "type": "great-sword",
     "name": "Executioner G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "barbaroi-blade-g",
     "type": "great-sword",
     "name": "Barbaroi Blade G",
     "rarity": 9,
-    "element": "fire"
+    "element": "fire",
+    "craftable": true
   },
   {
     "slug": "chrome-razor-g",
     "type": "great-sword",
     "name": "Chrome Razor G",
     "rarity": 9,
-    "element": "poison"
+    "element": "poison",
+    "craftable": true
   },
   {
     "slug": "plesioth-waterswd-g",
     "type": "great-sword",
     "name": "Plesioth Waterswd G",
     "rarity": 9,
-    "element": "water"
+    "element": "water",
+    "craftable": true
   },
   {
     "slug": "plesioth-crystaswd-g",
     "type": "great-sword",
     "name": "Plesioth Crystaswd G",
     "rarity": 9,
-    "element": "water"
+    "element": "water",
+    "craftable": true
   },
   {
     "slug": "killer-s-scythe-g",
     "type": "great-sword",
     "name": "Killer's Scythe G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "black-belt-blade-g",
     "type": "great-sword",
     "name": "Black Belt Blade G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "ancient-p-g",
     "type": "great-sword",
     "name": "Ancient P G",
     "rarity": 9,
-    "element": "dragon"
+    "element": "dragon",
+    "craftable": true
   },
   {
     "slug": "carbalite-sword-g",
     "type": "great-sword",
     "name": "Carbalite Sword G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "wyvern-agito-g",
     "type": "great-sword",
     "name": "Wyvern Agito G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "crystallized-tuna-g",
     "type": "great-sword",
     "name": "Crystallized Tuna G",
     "rarity": 9,
-    "element": "ice"
+    "element": "ice",
+    "craftable": true
   },
   {
     "slug": "judgment-g",
     "type": "great-sword",
     "name": "Judgment G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "true-dragon-s-jaw-g",
     "type": "great-sword",
     "name": "True Dragon's Jaw G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "tactical-blade-g",
     "type": "great-sword",
     "name": "Tactical Blade G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "rathalos-firesword-g",
     "type": "great-sword",
     "name": "Rathalos Firesword G",
     "rarity": 10,
-    "element": "fire"
+    "element": "fire",
+    "craftable": true
   },
   {
     "slug": "shinyrathalosswd-g",
     "type": "great-sword",
     "name": "ShinyRathalosSwd G",
     "rarity": 10,
-    "element": "fire"
+    "element": "fire",
+    "craftable": true
   },
   {
     "slug": "enforcer-s-axe-g",
     "type": "great-sword",
     "name": "Enforcer's Axe G",
-    "rarity": 10
+    "rarity": 10,
+    "craftable": true
   },
   {
     "slug": "siegmund-g",
     "type": "great-sword",
     "name": "Siegmund G",
-    "rarity": 10
+    "rarity": 10,
+    "craftable": true
   },
   {
     "slug": "sieglinde-g",
     "type": "great-sword",
     "name": "Sieglinde G",
-    "rarity": 10
+    "rarity": 10,
+    "craftable": true
   },
   {
     "slug": "pael-keizah-g",
     "type": "great-sword",
     "name": "Pael Keizah G",
     "rarity": 10,
-    "element": "dragon"
+    "element": "dragon",
+    "craftable": true
   },
   {
     "slug": "blushing-dame-g",
     "type": "great-sword",
     "name": "Blushing Dame G",
     "rarity": 10,
-    "element": "dragon"
+    "element": "dragon",
+    "craftable": true
   },
   {
     "slug": "eternlannihilator-g",
     "type": "great-sword",
     "name": "EternlAnnihilator G",
     "rarity": 10,
-    "element": "dragon"
+    "element": "dragon",
+    "craftable": true
   }
 ]
 }

--- a/content/blacksmith/gunlance/map.json
+++ b/content/blacksmith/gunlance/map.json
@@ -5,6 +5,7 @@
     "type": "gunlance",
     "name": "Bone Gunlance",
     "rarity": 1,
+    "craftable": true,
     "children": [
       {
         "slug": "great-bone-gunlance",
@@ -24,6 +25,7 @@
                 "name": "Hellsting",
                 "rarity": 4,
                 "element": "ice",
+                "craftable": true,
                 "children": [
                   {
                     "slug": "hellsting-plus",
@@ -74,6 +76,7 @@
             "name": "Average Hitter",
             "rarity": 3,
             "element": "poison",
+            "craftable": true,
             "children": [
               {
                 "slug": "grand-slam",
@@ -109,6 +112,7 @@
                             "name": "Venomous Cologne",
                             "rarity": 8,
                             "element": "poison",
+                            "craftable": true,
                             "children": [
                               {
                                 "slug": "venomous-attar",
@@ -164,6 +168,7 @@
                 "name": "Hellsting",
                 "rarity": 4,
                 "element": "ice",
+                "craftable": true,
                 "children": [
                   {
                     "slug": "hellsting-plus",
@@ -214,6 +219,7 @@
             "name": "Average Hitter",
             "rarity": 3,
             "element": "poison",
+            "craftable": true,
             "children": [
               {
                 "slug": "grand-slam",
@@ -249,6 +255,7 @@
                             "name": "Venomous Cologne",
                             "rarity": 8,
                             "element": "poison",
+                            "craftable": true,
                             "children": [
                               {
                                 "slug": "venomous-attar",
@@ -285,12 +292,14 @@
     "type": "lance",
     "name": "Iron Lance",
     "rarity": 1,
+    "craftable": true,
     "children": [
       {
         "slug": "iron-gunlance",
         "type": "gunlance",
         "name": "Iron Gunlance",
         "rarity": 1,
+        "craftable": true,
         "children": [
           {
             "slug": "iron-gunlance-plus",
@@ -309,6 +318,7 @@
                     "type": "gunlance",
                     "name": "Special Ops Gunlance",
                     "rarity": 3,
+                    "craftable": true,
                     "children": [
                       {
                         "slug": "imperial-gunlance",
@@ -360,6 +370,7 @@
                     "name": "Luna's Howl",
                     "rarity": 5,
                     "element": "fire",
+                    "craftable": true,
                     "children": [
                       {
                         "slug": "luna-s-roar",
@@ -438,6 +449,7 @@
         "name": "Snow Gunlance",
         "rarity": 2,
         "element": "ice",
+        "craftable": true,
         "children": [
           {
             "slug": "snow-gunlance-mk-ii",
@@ -459,6 +471,7 @@
                 "name": "Marine Fisher",
                 "rarity": 3,
                 "element": "water",
+                "craftable": true,
                 "children": [
                   {
                     "slug": "deep-fisher",
@@ -503,6 +516,7 @@
                                 "name": "Volcano Gunlance",
                                 "rarity": 9,
                                 "element": "fire",
+                                "craftable": true,
                                 "children": [
                                   {
                                     "slug": "lavasioth-gunlance",
@@ -526,6 +540,7 @@
                 "type": "gunlance",
                 "name": "Scissor Gunlance",
                 "rarity": 6,
+                "craftable": true,
                 "children": [
                   {
                     "slug": "scissor-cannon",
@@ -538,6 +553,7 @@
                         "type": "gunlance",
                         "name": "Violet Cannon",
                         "rarity": 9,
+                        "craftable": true,
                         "children": [
                           {
                             "slug": "violet-buster",
@@ -552,6 +568,7 @@
                         "type": "lance",
                         "name": "Shell Claw Lance",
                         "rarity": 9,
+                        "craftable": true,
                         "children": []
                       }
                     ]
@@ -575,6 +592,7 @@
         "type": "gunlance",
         "name": "Scissor Gunlance",
         "rarity": 6,
+        "craftable": true,
         "children": [
           {
             "slug": "scissor-cannon",
@@ -587,6 +605,7 @@
                 "type": "gunlance",
                 "name": "Violet Cannon",
                 "rarity": 9,
+                "craftable": true,
                 "children": [
                   {
                     "slug": "violet-buster",
@@ -601,6 +620,7 @@
                 "type": "lance",
                 "name": "Shell Claw Lance",
                 "rarity": 9,
+                "craftable": true,
                 "children": []
               }
             ]
@@ -615,6 +635,7 @@
     "name": "Black Smoke Gunlance",
     "rarity": 5,
     "element": "dragon",
+    "craftable": true,
     "children": [
       {
         "slug": "blackdragongunlance",
@@ -639,6 +660,7 @@
     "type": "gunlance",
     "name": "Rex Blast",
     "rarity": 5,
+    "craftable": true,
     "children": [
       {
         "slug": "tigrex-gunlance",
@@ -659,12 +681,14 @@
         "type": "gunlance",
         "name": "Hidden Gunlance",
         "rarity": 7,
+        "craftable": true,
         "children": [
           {
             "slug": "wanningmoondarklance",
             "type": "gunlance",
             "name": "WanningMoonDarklance",
-            "rarity": 10
+            "rarity": 10,
+            "craftable": true
           }
         ]
       }
@@ -676,6 +700,7 @@
     "name": "Dragonwood Gunlance",
     "rarity": 5,
     "element": "paralysis",
+    "craftable": true,
     "children": [
       {
         "slug": "gld-dragonwd-glance",
@@ -690,6 +715,7 @@
             "name": "AncientDrgnwoodLance",
             "rarity": 9,
             "element": "paralysis",
+            "craftable": true,
             "children": [
               {
                 "slug": "ancientdrgnwoodlanc-plus",
@@ -716,6 +742,7 @@
         "name": "Full Voltage",
         "rarity": 7,
         "element": "thunder",
+        "craftable": true,
         "children": [
           {
             "slug": "full-generator",
@@ -742,6 +769,7 @@
     "type": "lance",
     "name": "Knight Lance",
     "rarity": 6,
+    "craftable": true,
     "children": [
       {
         "slug": "feather-gunlance",
@@ -749,6 +777,7 @@
         "name": "Feather Gunlance",
         "rarity": 6,
         "element": "sleep",
+        "craftable": true,
         "children": [
           {
             "slug": "feather-gunlance-plus",
@@ -756,6 +785,7 @@
             "name": "Feather Gunlance+",
             "rarity": 9,
             "element": "sleep",
+            "craftable": true,
             "children": [
               {
                 "slug": "hypno-cannon",
@@ -775,6 +805,7 @@
     "type": "gunlance",
     "name": "Pop Corn",
     "rarity": 6,
+    "craftable": true,
     "children": [
       {
         "slug": "large-pop-corn",
@@ -795,6 +826,7 @@
         "type": "gunlance",
         "name": "Heavy Bone Gunlance",
         "rarity": 9,
+        "craftable": true,
         "children": [
           {
             "slug": "hard-bone-cannon",
@@ -817,6 +849,7 @@
         "type": "gunlance",
         "name": "Ancient Destroyer",
         "rarity": 9,
+        "craftable": true,
         "children": [
           {
             "slug": "genesis",
@@ -833,6 +866,7 @@
     "type": "gunlance",
     "name": "Akantor Gunlance",
     "rarity": 8,
+    "craftable": true,
     "children": [
       {
         "slug": "akantornoirgunlance",
@@ -846,72 +880,83 @@
     "slug": "dummy-eldrdrgglanceemblem",
     "type": "gunlance",
     "name": "dummy (EldrDrgGLance\"Emblem\")",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "ukanlosblazegunlance",
     "type": "gunlance",
     "name": "UkanlosBlazeGunlance",
     "rarity": 10,
-    "element": "ice"
+    "element": "ice",
+    "craftable": true
   },
   {
     "slug": "iron-gunlance-g",
     "type": "gunlance",
     "name": "Iron Gunlance G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "wyvernbone-gunlance-g",
     "type": "gunlance",
     "name": "WyvernBone Gunlance G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "blizzard-gunlance-g",
     "type": "gunlance",
     "name": "Blizzard Gunlance G",
     "rarity": 9,
-    "element": "ice"
+    "element": "ice",
+    "craftable": true
   },
   {
     "slug": "imperial-gunlance-g",
     "type": "gunlance",
     "name": "Imperial Gunlance G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "scissor-cannon-g",
     "type": "gunlance",
     "name": "Scissor Cannon G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "grand-slam-g",
     "type": "gunlance",
     "name": "Grand Slam G",
     "rarity": 9,
-    "element": "poison"
+    "element": "poison",
+    "craftable": true
   },
   {
     "slug": "marine-fisher-g",
     "type": "gunlance",
     "name": "Marine Fisher G",
     "rarity": 9,
-    "element": "water"
+    "element": "water",
+    "craftable": true
   },
   {
     "slug": "white-cannon-g",
     "type": "gunlance",
     "name": "White Cannon G",
-    "rarity": 10
+    "rarity": 10,
+    "craftable": true
   },
   {
     "slug": "gld-dragonwd-glance-g",
     "type": "gunlance",
     "name": "Gld Dragonwd GLance G",
     "rarity": 10,
-    "element": "paralysis"
+    "element": "paralysis",
+    "craftable": true
   }
 ]
 }

--- a/content/blacksmith/hammer/map.json
+++ b/content/blacksmith/hammer/map.json
@@ -5,12 +5,14 @@
     "type": "hammer",
     "name": "War Hammer",
     "rarity": 1,
+    "craftable": true,
     "children": [
       {
         "slug": "war-hammer-plus",
         "type": "hammer",
         "name": "War Hammer+",
         "rarity": 1,
+        "craftable": true,
         "children": [
           {
             "slug": "war-mace",
@@ -23,12 +25,14 @@
                 "type": "hammer",
                 "name": "Iron Striker",
                 "rarity": 2,
+                "craftable": true,
                 "children": [
                   {
                     "slug": "iron-striker-plus",
                     "type": "hammer",
                     "name": "Iron Striker+",
                     "rarity": 2,
+                    "craftable": true,
                     "children": [
                       {
                         "slug": "anvil-hammer",
@@ -47,6 +51,7 @@
                                 "type": "hammer",
                                 "name": "Blacksmith",
                                 "rarity": 9,
+                                "craftable": true,
                                 "children": [
                                   {
                                     "slug": "juggernaut",
@@ -60,6 +65,7 @@
                                     "name": "Lava Alphorn",
                                     "rarity": 9,
                                     "element": "fire",
+                                    "craftable": true,
                                     "children": []
                                   }
                                 ]
@@ -85,6 +91,7 @@
                             "type": "hunting-horn",
                             "name": "Bronze Bell",
                             "rarity": 5,
+                            "craftable": true,
                             "children": []
                           },
                           {
@@ -93,6 +100,7 @@
                             "name": "Sakura Recorder",
                             "rarity": 5,
                             "element": "dragon",
+                            "craftable": true,
                             "children": []
                           },
                           {
@@ -100,6 +108,7 @@
                             "type": "hammer",
                             "name": "Iron Devil",
                             "rarity": 6,
+                            "craftable": true,
                             "children": [
                               {
                                 "slug": "great-demon-hammer",
@@ -150,6 +159,7 @@
                                         "name": "Icy Impact",
                                         "rarity": 9,
                                         "element": "ice",
+                                        "craftable": true,
                                         "children": [
                                           {
                                             "slug": "axion",
@@ -198,6 +208,7 @@
                     "name": "Gunhammer Prototype",
                     "rarity": 3,
                     "element": "fire",
+                    "craftable": true,
                     "children": [
                       {
                         "slug": "dead-revolver",
@@ -219,6 +230,7 @@
                                 "name": "Regulation GunHammer",
                                 "rarity": 9,
                                 "element": "fire",
+                                "craftable": true,
                                 "children": [
                                   {
                                     "slug": "imperialgunhmmrspark",
@@ -267,6 +279,7 @@
                 "type": "hammer",
                 "name": "Black Cauldron",
                 "rarity": 3,
+                "craftable": true,
                 "children": [
                   {
                     "slug": "true-black-cauldron",
@@ -313,6 +326,7 @@
                             "type": "hammer",
                             "name": "Ceanataur Head Axe",
                             "rarity": 7,
+                            "craftable": true,
                             "children": [
                               {
                                 "slug": "big-blue-chopper",
@@ -326,6 +340,7 @@
                                 "name": "Carmine Axe",
                                 "rarity": 9,
                                 "element": "water",
+                                "craftable": true,
                                 "children": [
                                   {
                                     "slug": "the-great-divider",
@@ -349,6 +364,7 @@
                 "type": "hunting-horn",
                 "name": "Metal Bagpipe",
                 "rarity": 2,
+                "craftable": true,
                 "children": []
               }
             ]
@@ -370,6 +386,7 @@
                     "type": "hammer",
                     "name": "Crystal Hammer",
                     "rarity": 3,
+                    "craftable": true,
                     "children": [
                       {
                         "slug": "crystal-nova",
@@ -417,6 +434,7 @@
                     "name": "Shell Hammer",
                     "rarity": 4,
                     "element": "poison",
+                    "craftable": true,
                     "children": [
                       {
                         "slug": "graviton-hammer",
@@ -476,6 +494,7 @@
                     "name": "Basarios Rock",
                     "rarity": 4,
                     "element": "fire",
+                    "craftable": true,
                     "children": []
                   }
                 ]
@@ -491,6 +510,7 @@
     "type": "hammer",
     "name": "Bone Club",
     "rarity": 1,
+    "craftable": true,
     "children": [
       {
         "slug": "large-bone-club",
@@ -519,6 +539,7 @@
         "type": "hammer",
         "name": "Cyclo-Hammer",
         "rarity": 1,
+        "craftable": true,
         "children": [
           {
             "slug": "atlas-hammer",
@@ -531,18 +552,21 @@
                 "type": "hammer",
                 "name": "Kut-Ku Jaw",
                 "rarity": 3,
+                "craftable": true,
                 "children": [
                   {
                     "slug": "kut-ku-pick",
                     "type": "hammer",
                     "name": "Kut-Ku Pick",
                     "rarity": 4,
+                    "craftable": true,
                     "children": [
                       {
                         "slug": "hard-bone-hammer",
                         "type": "hammer",
                         "name": "Hard Bone Hammer",
                         "rarity": 6,
+                        "craftable": true,
                         "children": [
                           {
                             "slug": "hard-bone-hammer-plus",
@@ -607,6 +631,7 @@
                         "name": "Feather Whistle",
                         "rarity": 6,
                         "element": "sleep",
+                        "craftable": true,
                         "children": []
                       }
                     ]
@@ -616,6 +641,7 @@
                     "type": "hammer",
                     "name": "Raven Torrent",
                     "rarity": 5,
+                    "craftable": true,
                     "children": [
                       {
                         "slug": "wolf-torrent",
@@ -635,6 +661,7 @@
                             "name": "Wolf Shamisen",
                             "rarity": 7,
                             "element": "poison",
+                            "craftable": true,
                             "children": []
                           }
                         ]
@@ -721,6 +748,7 @@
                 "name": "Khezu Horn",
                 "rarity": 3,
                 "element": "thunder",
+                "craftable": true,
                 "children": []
               }
             ]
@@ -742,6 +770,7 @@
                     "type": "hammer",
                     "name": "Diablos Maul",
                     "rarity": 4,
+                    "craftable": true,
                     "children": [
                       {
                         "slug": "finishing-hammer",
@@ -756,6 +785,7 @@
                     "type": "hammer",
                     "name": "Dragonhead Hammer",
                     "rarity": 3,
+                    "craftable": true,
                     "children": [
                       {
                         "slug": "ancient-relic",
@@ -769,6 +799,7 @@
                             "name": "Shell Castanet",
                             "rarity": 7,
                             "element": "water",
+                            "craftable": true,
                             "children": []
                           }
                         ]
@@ -794,6 +825,7 @@
                     "type": "hunting-horn",
                     "name": "Sonic Glass",
                     "rarity": 3,
+                    "craftable": true,
                     "children": []
                   }
                 ]
@@ -826,6 +858,7 @@
                         "type": "hammer",
                         "name": "Desert Cone",
                         "rarity": 9,
+                        "craftable": true,
                         "children": [
                           {
                             "slug": "magnitude",
@@ -846,6 +879,7 @@
             "type": "hunting-horn",
             "name": "Bone Horn",
             "rarity": 2,
+            "craftable": true,
             "children": []
           }
         ]
@@ -855,6 +889,7 @@
         "type": "hammer",
         "name": "Bull Hammer",
         "rarity": 2,
+        "craftable": true,
         "children": [
           {
             "slug": "bull-head-hammer",
@@ -878,6 +913,7 @@
         "name": "Giaprey Balloon",
         "rarity": 2,
         "element": "ice",
+        "craftable": true,
         "children": []
       }
     ]
@@ -887,6 +923,7 @@
     "type": "hammer",
     "name": "Rusted Hammer",
     "rarity": 1,
+    "craftable": true,
     "children": [
       {
         "slug": "tarnished-hammer",
@@ -944,6 +981,7 @@
     "name": "White Cat Stamp",
     "rarity": 2,
     "element": "paralysis",
+    "craftable": true,
     "children": [
       {
         "slug": "white-cat-hammer",
@@ -972,6 +1010,7 @@
             "name": "Gold Cat Hammer",
             "rarity": 8,
             "element": "paralysis",
+            "craftable": true,
             "children": [
               {
                 "slug": "gold-cat-crusher",
@@ -989,7 +1028,8 @@
         "type": "hammer",
         "name": "Teddybear",
         "rarity": 4,
-        "element": "sleep"
+        "element": "sleep",
+        "craftable": true
       }
     ]
   },
@@ -999,6 +1039,7 @@
     "name": "Cactus Creamer",
     "rarity": 3,
     "element": "poison",
+    "craftable": true,
     "children": [
       {
         "slug": "green-monster",
@@ -1022,6 +1063,7 @@
         "name": "Purse Bop",
         "rarity": 7,
         "element": "thunder",
+        "craftable": true,
         "children": [
           {
             "slug": "purse-bop-plus",
@@ -1049,6 +1091,7 @@
     "name": "dummy (Amezari Hammer)",
     "rarity": 4,
     "element": "water",
+    "craftable": true,
     "children": [
       {
         "slug": "dummy-amezari-hammer-plus",
@@ -1074,6 +1117,7 @@
     "name": "dummy (Polytan)",
     "rarity": 4,
     "element": "thunder",
+    "craftable": true,
     "children": [
       {
         "slug": "dummy-polytan-g",
@@ -1098,6 +1142,7 @@
     "type": "hammer",
     "name": "Black Belt Hammer",
     "rarity": 4,
+    "craftable": true,
     "children": [
       {
         "slug": "expert-hammer",
@@ -1120,6 +1165,7 @@
     "type": "hammer",
     "name": "Striped Striker",
     "rarity": 5,
+    "craftable": true,
     "children": [
       {
         "slug": "tigrex-hammer",
@@ -1140,12 +1186,14 @@
         "type": "hammer",
         "name": "Hidden Breaker",
         "rarity": 7,
+        "craftable": true,
         "children": [
           {
             "slug": "deep-darkhammer",
             "type": "hammer",
             "name": "Deep Darkhammer",
-            "rarity": 10
+            "rarity": 10,
+            "craftable": true
           }
         ]
       }
@@ -1157,6 +1205,7 @@
     "name": "Dragon Destroyer",
     "rarity": 5,
     "element": "dragon",
+    "craftable": true,
     "children": [
       {
         "slug": "dragonbreaker",
@@ -1191,6 +1240,7 @@
     "name": "Black Hammer",
     "rarity": 5,
     "element": "dragon",
+    "craftable": true,
     "children": [
       {
         "slug": "fatalis-buster",
@@ -1231,6 +1281,7 @@
     "type": "hammer",
     "name": "Worn Hammer",
     "rarity": 6,
+    "craftable": true,
     "children": [
       {
         "slug": "weathered-hammer",
@@ -1286,255 +1337,295 @@
     "type": "hammer",
     "name": "Ukanlos Trampler",
     "rarity": 10,
-    "element": "ice"
+    "element": "ice",
+    "craftable": true
   },
   {
     "slug": "bone-club-g",
     "type": "hammer",
     "name": "Bone Club G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "war-hammer-g",
     "type": "hammer",
     "name": "War Hammer G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "tarnished-hammer-g",
     "type": "hammer",
     "name": "Tarnished Hammer G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "spiked-hammer-g",
     "type": "hammer",
     "name": "Spiked Hammer G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "iron-striker-g",
     "type": "hammer",
     "name": "Iron Striker G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "atlas-hammer-g",
     "type": "hammer",
     "name": "Atlas Hammer G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "bone-axe-g",
     "type": "hammer",
     "name": "Bone Axe G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "skullcrusher-g",
     "type": "hammer",
     "name": "Skullcrusher G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "bull-tusk-hammer-g",
     "type": "hammer",
     "name": "Bull Tusk Hammer G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "crystal-nova-g",
     "type": "hammer",
     "name": "Crystal Nova G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "binder-mace-g",
     "type": "hammer",
     "name": "Binder Mace G",
     "rarity": 9,
-    "element": "paralysis"
+    "element": "paralysis",
+    "craftable": true
   },
   {
     "slug": "kut-ku-jaw-g",
     "type": "hammer",
     "name": "Kut-Ku Jaw G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "venom-monster-g",
     "type": "hammer",
     "name": "Venom Monster G",
     "rarity": 9,
-    "element": "poison"
+    "element": "poison",
+    "craftable": true
   },
   {
     "slug": "dead-revolver-g",
     "type": "hammer",
     "name": "Dead Revolver G",
     "rarity": 9,
-    "element": "fire"
+    "element": "fire",
+    "craftable": true
   },
   {
     "slug": "anchor-crusher-g",
     "type": "hammer",
     "name": "Anchor Crusher G",
     "rarity": 9,
-    "element": "water"
+    "element": "water",
+    "craftable": true
   },
   {
     "slug": "kut-ku-pick-g",
     "type": "hammer",
     "name": "Kut-Ku Pick G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "dragonhead-hammer-g",
     "type": "hammer",
     "name": "Dragonhead Hammer G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "basarios-bash-g",
     "type": "hammer",
     "name": "Basarios Bash G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "titan-hammer-g",
     "type": "hammer",
     "name": "Titan Hammer G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "finishing-hammer-g",
     "type": "hammer",
     "name": "Finishing Hammer G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "trueblackcauldron-g",
     "type": "hammer",
     "name": "TrueBlackCauldron G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "enormous-ham-g",
     "type": "hammer",
     "name": "Enormous Ham G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "teddybear-g",
     "type": "hammer",
     "name": "Teddybear G",
     "rarity": 9,
-    "element": "sleep"
+    "element": "sleep",
+    "craftable": true
   },
   {
     "slug": "cactus-creamer-g",
     "type": "hammer",
     "name": "Cactus Creamer G",
     "rarity": 9,
-    "element": "poison"
+    "element": "poison",
+    "craftable": true
   },
   {
     "slug": "white-cat-hammer-g",
     "type": "hammer",
     "name": "White Cat Hammer G",
     "rarity": 9,
-    "element": "paralysis"
+    "element": "paralysis",
+    "craftable": true
   },
   {
     "slug": "black-cat-hammer-g",
     "type": "hammer",
     "name": "Black Cat Hammer G",
     "rarity": 9,
-    "element": "paralysis"
+    "element": "paralysis",
+    "craftable": true
   },
   {
     "slug": "black-belt-hammer-g",
     "type": "hammer",
     "name": "Black Belt Hammer G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "breath-core-hammer-g",
     "type": "hammer",
     "name": "Breath Core Hammer G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "polytan-g",
     "type": "hammer",
     "name": "Polytan G",
     "rarity": 9,
-    "element": "thunder"
+    "element": "thunder",
+    "craftable": true
   },
   {
     "slug": "great-demon-hammer-g",
     "type": "hammer",
     "name": "Great Demon Hammer G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "hard-bone-hammer-g",
     "type": "hammer",
     "name": "Hard Bone Hammer G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "twostarsilverpot-g",
     "type": "hammer",
     "name": "TwoStarSilverPot G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "great-cone-g",
     "type": "hammer",
     "name": "Great Cone G",
     "rarity": 9,
-    "element": "ice"
+    "element": "ice",
+    "craftable": true
   },
   {
     "slug": "onslaught-hammer-g",
     "type": "hammer",
     "name": "Onslaught Hammer G",
-    "rarity": 10
+    "rarity": 10,
+    "craftable": true
   },
   {
     "slug": "war-basher-g",
     "type": "hammer",
     "name": "War Basher G",
-    "rarity": 10
+    "rarity": 10,
+    "craftable": true
   },
   {
     "slug": "sanctionedgunhammr-g",
     "type": "hammer",
     "name": "SanctionedGunHammr G",
     "rarity": 10,
-    "element": "fire"
+    "element": "fire",
+    "craftable": true
   },
   {
     "slug": "crater-maker-g",
     "type": "hammer",
     "name": "Crater Maker G",
     "rarity": 10,
-    "element": "poison"
+    "element": "poison",
+    "craftable": true
   },
   {
     "slug": "tormentpurgatory-g",
     "type": "hammer",
     "name": "Torment(Purgatory) G",
     "rarity": 10,
-    "element": "fire"
+    "element": "fire",
+    "craftable": true
   },
   {
     "slug": "dragonbreaker-g",
     "type": "hammer",
     "name": "Dragonbreaker G",
     "rarity": 10,
-    "element": "dragon"
+    "element": "dragon",
+    "craftable": true
   }
 ]
 }

--- a/content/blacksmith/heavy-bowgun/map.json
+++ b/content/blacksmith/heavy-bowgun/map.json
@@ -4,619 +4,722 @@
     "slug": "bone-shooter",
     "type": "heavy-bowgun",
     "name": "Bone Shooter",
-    "rarity": 1
+    "rarity": 1,
+    "craftable": true
   },
   {
     "slug": "injector-cannon",
     "type": "heavy-bowgun",
     "name": "Injector Cannon",
-    "rarity": 2
+    "rarity": 2,
+    "craftable": true
   },
   {
     "slug": "rapidcaster",
     "type": "heavy-bowgun",
     "name": "Rapidcaster",
-    "rarity": 2
+    "rarity": 2,
+    "craftable": true
   },
   {
     "slug": "tankmage",
     "type": "heavy-bowgun",
     "name": "Tankmage",
-    "rarity": 3
+    "rarity": 3,
+    "craftable": true
   },
   {
     "slug": "bastionmage",
     "type": "heavy-bowgun",
     "name": "Bastionmage",
-    "rarity": 3
+    "rarity": 3,
+    "craftable": true
   },
   {
     "slug": "sand-driver",
     "type": "heavy-bowgun",
     "name": "Sand Driver",
-    "rarity": 3
+    "rarity": 3,
+    "craftable": true
   },
   {
     "slug": "yian-kut-ku-cannon",
     "type": "heavy-bowgun",
     "name": "Yian Kut-Ku Cannon",
-    "rarity": 3
+    "rarity": 3,
+    "craftable": true
   },
   {
     "slug": "crab-buster",
     "type": "heavy-bowgun",
     "name": "Crab Buster",
-    "rarity": 3
+    "rarity": 3,
+    "craftable": true
   },
   {
     "slug": "rock-eater",
     "type": "heavy-bowgun",
     "name": "Rock Eater",
-    "rarity": 4
+    "rarity": 4,
+    "craftable": true
   },
   {
     "slug": "meteor-cannon",
     "type": "heavy-bowgun",
     "name": "Meteor Cannon",
-    "rarity": 4
+    "rarity": 4,
+    "craftable": true
   },
   {
     "slug": "flechette-gun",
     "type": "heavy-bowgun",
     "name": "Flechette Gun",
-    "rarity": 4
+    "rarity": 4,
+    "craftable": true
   },
   {
     "slug": "monodevilcaster",
     "type": "heavy-bowgun",
     "name": "Monodevilcaster",
-    "rarity": 4
+    "rarity": 4,
+    "craftable": true
   },
   {
     "slug": "piercing-crab",
     "type": "heavy-bowgun",
     "name": "Piercing Crab",
-    "rarity": 4
+    "rarity": 4,
+    "craftable": true
   },
   {
     "slug": "blue-kut-ku-cannon",
     "type": "heavy-bowgun",
     "name": "Blue Kut-Ku Cannon",
-    "rarity": 4
+    "rarity": 4,
+    "craftable": true
   },
   {
     "slug": "duelcaster",
     "type": "heavy-bowgun",
     "name": "Duelcaster",
-    "rarity": 4
+    "rarity": 4,
+    "craftable": true
   },
   {
     "slug": "tigrex-howl",
     "type": "heavy-bowgun",
     "name": "Tigrex Howl",
-    "rarity": 4
+    "rarity": 4,
+    "craftable": true
   },
   {
     "slug": "seven-nova",
     "type": "heavy-bowgun",
     "name": "Seven Nova",
-    "rarity": 5
+    "rarity": 5,
+    "craftable": true
   },
   {
     "slug": "quickcaster",
     "type": "heavy-bowgun",
     "name": "Quickcaster",
-    "rarity": 5
+    "rarity": 5,
+    "craftable": true
   },
   {
     "slug": "black-cannon",
     "type": "heavy-bowgun",
     "name": "Black Cannon",
-    "rarity": 5
+    "rarity": 5,
+    "craftable": true
   },
   {
     "slug": "raven-heirloom",
     "type": "heavy-bowgun",
     "name": "Raven Heirloom",
-    "rarity": 5
+    "rarity": 5,
+    "craftable": true
   },
   {
     "slug": "daora-s-delphinidae",
     "type": "heavy-bowgun",
     "name": "Daora's Delphinidae",
-    "rarity": 5
+    "rarity": 5,
+    "craftable": true
   },
   {
     "slug": "lunastra-s-cannon",
     "type": "heavy-bowgun",
     "name": "Lunastra's Cannon",
-    "rarity": 5
+    "rarity": 5,
+    "craftable": true
   },
   {
     "slug": "teostra-s-artillery",
     "type": "heavy-bowgun",
     "name": "Teostra's Artillery",
-    "rarity": 5
+    "rarity": 5,
+    "craftable": true
   },
   {
     "slug": "bronze-fire",
     "type": "heavy-bowgun",
     "name": "Bronze Fire",
-    "rarity": 5
+    "rarity": 5,
+    "craftable": true
   },
   {
     "slug": "lao-shan-lung-cannon",
     "type": "heavy-bowgun",
     "name": "Lao-Shan Lung Cannon",
-    "rarity": 5
+    "rarity": 5,
+    "craftable": true
   },
   {
     "slug": "great-arbalest",
     "type": "heavy-bowgun",
     "name": "Great Arbalest",
-    "rarity": 6
+    "rarity": 6,
+    "craftable": true
   },
   {
     "slug": "tankmage-plus",
     "type": "heavy-bowgun",
     "name": "Tankmage+",
-    "rarity": 6
+    "rarity": 6,
+    "craftable": true
   },
   {
     "slug": "desert-diver",
     "type": "heavy-bowgun",
     "name": "Desert Diver",
-    "rarity": 6
+    "rarity": 6,
+    "craftable": true
   },
   {
     "slug": "meteor-buster",
     "type": "heavy-bowgun",
     "name": "Meteor Buster",
-    "rarity": 6
+    "rarity": 6,
+    "craftable": true
   },
   {
     "slug": "honeycomber",
     "type": "heavy-bowgun",
     "name": "Honeycomber",
-    "rarity": 6
+    "rarity": 6,
+    "craftable": true
   },
   {
     "slug": "earth-eater",
     "type": "heavy-bowgun",
     "name": "Earth Eater",
-    "rarity": 6
+    "rarity": 6,
+    "craftable": true
   },
   {
     "slug": "heavy-buster-crab",
     "type": "heavy-bowgun",
     "name": "Heavy Buster Crab",
-    "rarity": 6
+    "rarity": 6,
+    "craftable": true
   },
   {
     "slug": "gravios-howl",
     "type": "heavy-bowgun",
     "name": "Gravios Howl",
-    "rarity": 6
+    "rarity": 6,
+    "craftable": true
   },
   {
     "slug": "heavy-piercing-crab",
     "type": "heavy-bowgun",
     "name": "Heavy Piercing Crab",
-    "rarity": 6
+    "rarity": 6,
+    "craftable": true
   },
   {
     "slug": "duelcaster-plus",
     "type": "heavy-bowgun",
     "name": "Duelcaster+",
-    "rarity": 6
+    "rarity": 6,
+    "craftable": true
   },
   {
     "slug": "tigrex-skull",
     "type": "heavy-bowgun",
     "name": "Tigrex Skull",
-    "rarity": 6
+    "rarity": 6,
+    "craftable": true
   },
   {
     "slug": "hidden-sniper",
     "type": "heavy-bowgun",
     "name": "Hidden Sniper",
-    "rarity": 7
+    "rarity": 7,
+    "craftable": true
   },
   {
     "slug": "bastion-cannon",
     "type": "heavy-bowgun",
     "name": "Bastion Cannon",
-    "rarity": 7
+    "rarity": 7,
+    "craftable": true
   },
   {
     "slug": "gravios-roar",
     "type": "heavy-bowgun",
     "name": "Gravios Roar",
-    "rarity": 7
+    "rarity": 7,
+    "craftable": true
   },
   {
     "slug": "mega-kut-ku-cannon",
     "type": "heavy-bowgun",
     "name": "Mega Kut-Ku Cannon",
-    "rarity": 7
+    "rarity": 7,
+    "craftable": true
   },
   {
     "slug": "monodevilcaster-plus",
     "type": "heavy-bowgun",
     "name": "Monodevilcaster+",
-    "rarity": 7
+    "rarity": 7,
+    "craftable": true
   },
   {
     "slug": "seven-stars",
     "type": "heavy-bowgun",
     "name": "Seven Stars",
-    "rarity": 8
+    "rarity": 8,
+    "craftable": true
   },
   {
     "slug": "quickcaster-plus",
     "type": "heavy-bowgun",
     "name": "Quickcaster+",
-    "rarity": 8
+    "rarity": 8,
+    "craftable": true
   },
   {
     "slug": "grande-daora",
     "type": "heavy-bowgun",
     "name": "Grande Daora",
-    "rarity": 8
+    "rarity": 8,
+    "craftable": true
   },
   {
     "slug": "vor-cannon",
     "type": "heavy-bowgun",
     "name": "Vor Cannon",
-    "rarity": 8
+    "rarity": 8,
+    "craftable": true
   },
   {
     "slug": "lunastra-s-flames",
     "type": "heavy-bowgun",
     "name": "Lunastra's Flames",
-    "rarity": 8
+    "rarity": 8,
+    "craftable": true
   },
   {
     "slug": "teostra-s-flames",
     "type": "heavy-bowgun",
     "name": "Teostra's Flames",
-    "rarity": 8
+    "rarity": 8,
+    "craftable": true
   },
   {
     "slug": "destiny-s-hands",
     "type": "heavy-bowgun",
     "name": "Destiny's Hands",
-    "rarity": 8
+    "rarity": 8,
+    "craftable": true
   },
   {
     "slug": "wolf-heirloom",
     "type": "heavy-bowgun",
     "name": "Wolf Heirloom",
-    "rarity": 8
+    "rarity": 8,
+    "craftable": true
   },
   {
     "slug": "gaoren-s-fire",
     "type": "heavy-bowgun",
     "name": "Gaoren's Fire",
-    "rarity": 8
+    "rarity": 8,
+    "craftable": true
   },
   {
     "slug": "suprm-lao-shan-cannon",
     "type": "heavy-bowgun",
     "name": "Suprm Lao-Shan Cannon",
-    "rarity": 8
+    "rarity": 8,
+    "craftable": true
   },
   {
     "slug": "empr-lao-shan-cannon",
     "type": "heavy-bowgun",
     "name": "Empr Lao-Shan Cannon",
-    "rarity": 8
+    "rarity": 8,
+    "craftable": true
   },
   {
     "slug": "great-arbalest-plus",
     "type": "heavy-bowgun",
     "name": "Great Arbalest+",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "tanksorcerer",
     "type": "heavy-bowgun",
     "name": "Tanksorcerer",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "bastionwitch",
     "type": "heavy-bowgun",
     "name": "Bastionwitch",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "power-stinger",
     "type": "heavy-bowgun",
     "name": "Power Stinger",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "pressurized-plesioth",
     "type": "heavy-bowgun",
     "name": "Pressurized Plesioth",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "violet-punisher",
     "type": "heavy-bowgun",
     "name": "Violet Punisher",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "super-kut-ku-cannon",
     "type": "heavy-bowgun",
     "name": "Super Kut-Ku Cannon",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "ultra-kut-ku-cannon",
     "type": "heavy-bowgun",
     "name": "Ultra Kut-Ku Cannon",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "meteor-shower",
     "type": "heavy-bowgun",
     "name": "Meteor Shower",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "gaia-eater",
     "type": "heavy-bowgun",
     "name": "Gaia Eater",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "icethrower",
     "type": "heavy-bowgun",
     "name": "Icethrower",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "ceanataur-blaster",
     "type": "heavy-bowgun",
     "name": "Ceanataur Blaster",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "gravios-gigahowl",
     "type": "heavy-bowgun",
     "name": "Gravios gigahowl",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "dummy-pirate-j-cannon",
     "type": "heavy-bowgun",
     "name": "dummy (Pirate J Cannon)",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "queen-needle",
     "type": "heavy-bowgun",
     "name": "Queen Needle",
-    "rarity": 10
+    "rarity": 10,
+    "craftable": true
   },
   {
     "slug": "evil-wind-darkcannon",
     "type": "heavy-bowgun",
     "name": "Evil Wind Darkcannon",
-    "rarity": 10
+    "rarity": 10,
+    "craftable": true
   },
   {
     "slug": "greatladybugcannon-plus",
     "type": "heavy-bowgun",
     "name": "GreatLadybugCannon+",
-    "rarity": 10
+    "rarity": 10,
+    "craftable": true
   },
   {
     "slug": "quick-quiver",
     "type": "heavy-bowgun",
     "name": "Quick Quiver",
-    "rarity": 10
+    "rarity": 10,
+    "craftable": true
   },
   {
     "slug": "crow-heirloom",
     "type": "heavy-bowgun",
     "name": "Crow Heirloom",
-    "rarity": 10
+    "rarity": 10,
+    "craftable": true
   },
   {
     "slug": "terra-c-blaster",
     "type": "heavy-bowgun",
     "name": "Terra C Blaster",
-    "rarity": 10
+    "rarity": 10,
+    "craftable": true
   },
   {
     "slug": "daora-s-ceti",
     "type": "heavy-bowgun",
     "name": "Daora's Ceti",
-    "rarity": 10
+    "rarity": 10,
+    "craftable": true
   },
   {
     "slug": "destiny-s-arm",
     "type": "heavy-bowgun",
     "name": "Destiny's Arm",
-    "rarity": 10
+    "rarity": 10,
+    "craftable": true
   },
   {
     "slug": "gravios-gigaroar",
     "type": "heavy-bowgun",
     "name": "Gravios Gigaroar",
-    "rarity": 10
+    "rarity": 10,
+    "craftable": true
   },
   {
     "slug": "teostra-flamethrower",
     "type": "heavy-bowgun",
     "name": "Teostra Flamethrower",
-    "rarity": 10
+    "rarity": 10,
+    "craftable": true
   },
   {
     "slug": "dark-duelcaster",
     "type": "heavy-bowgun",
     "name": "Dark Duelcaster",
-    "rarity": 10
+    "rarity": 10,
+    "craftable": true
   },
   {
     "slug": "vor-buster",
     "type": "heavy-bowgun",
     "name": "Vor Buster",
-    "rarity": 10
+    "rarity": 10,
+    "craftable": true
   },
   {
     "slug": "tigrex-skull-plus",
     "type": "heavy-bowgun",
     "name": "Tigrex Skull+",
-    "rarity": 10
+    "rarity": 10,
+    "craftable": true
   },
   {
     "slug": "gaoren-orb",
     "type": "heavy-bowgun",
     "name": "Gaoren Orb",
-    "rarity": 10
+    "rarity": 10,
+    "craftable": true
   },
   {
     "slug": "ancientdrgnwoodcan",
     "type": "heavy-bowgun",
     "name": "AncientDrgnwoodCan",
-    "rarity": 10
+    "rarity": 10,
+    "craftable": true
   },
   {
     "slug": "ultimatelao-shaocan",
     "type": "heavy-bowgun",
     "name": "UltimateLao-ShaoCan",
-    "rarity": 10
+    "rarity": 10,
+    "craftable": true
   },
   {
     "slug": "ukanlos-cannon",
     "type": "heavy-bowgun",
     "name": "Ukanlos Cannon",
-    "rarity": 10
+    "rarity": 10,
+    "craftable": true
   },
   {
     "slug": "arbalest-g",
     "type": "heavy-bowgun",
     "name": "Arbalest G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "rapidcaster-g",
     "type": "heavy-bowgun",
     "name": "Rapidcaster G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "injector-cannon-g",
     "type": "heavy-bowgun",
     "name": "Injector Cannon G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "honeycomber-g",
     "type": "heavy-bowgun",
     "name": "Honeycomber G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "tanksorcerer-g",
     "type": "heavy-bowgun",
     "name": "Tanksorcerer G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "bastionwitch-g",
     "type": "heavy-bowgun",
     "name": "Bastionwitch G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "desert-diver-g",
     "type": "heavy-bowgun",
     "name": "Desert Diver G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "power-stinger-g",
     "type": "heavy-bowgun",
     "name": "Power Stinger G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "crab-buster-g",
     "type": "heavy-bowgun",
     "name": "Crab Buster G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "meteor-cannon-g",
     "type": "heavy-bowgun",
     "name": "Meteor Cannon G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "pressurizedplesiothg",
     "type": "heavy-bowgun",
     "name": "PressurizedPlesiothG",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "violet-punisher-g",
     "type": "heavy-bowgun",
     "name": "Violet Punisher G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "superkut-kucannon-g",
     "type": "heavy-bowgun",
     "name": "SuperKut-KuCannon G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "ultrakut-kucannon-g",
     "type": "heavy-bowgun",
     "name": "UltraKut-KuCannon G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "monodevilcaster-g",
     "type": "heavy-bowgun",
     "name": "Monodevilcaster G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "duelcaster-g",
     "type": "heavy-bowgun",
     "name": "Duelcaster G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "queen-needle-g",
     "type": "heavy-bowgun",
     "name": "Queen Needle G",
-    "rarity": 10
+    "rarity": 10,
+    "craftable": true
   },
   {
     "slug": "black-cannon-g",
     "type": "heavy-bowgun",
     "name": "Black Cannon G",
-    "rarity": 10
+    "rarity": 10,
+    "craftable": true
   },
   {
     "slug": "lunastra-s-flames-g",
     "type": "heavy-bowgun",
     "name": "Lunastra's Flames G",
-    "rarity": 10
+    "rarity": 10,
+    "craftable": true
   },
   {
     "slug": "lao-shanlungcannon-g",
     "type": "heavy-bowgun",
     "name": "Lao-ShanLungCannon G",
-    "rarity": 10
+    "rarity": 10,
+    "craftable": true
   }
 ]
 }

--- a/content/blacksmith/hunting-horn/map.json
+++ b/content/blacksmith/hunting-horn/map.json
@@ -5,12 +5,14 @@
     "type": "hunting-horn",
     "name": "Ivory Horn",
     "rarity": 1,
+    "craftable": true,
     "children": [
       {
         "slug": "bone-horn",
         "type": "hunting-horn",
         "name": "Bone Horn",
         "rarity": 2,
+        "craftable": true,
         "children": [
           {
             "slug": "bone-horn-plus",
@@ -48,6 +50,7 @@
             "name": "Blessed Ocarina",
             "rarity": 5,
             "element": "poison",
+            "craftable": true,
             "children": [
               {
                 "slug": "cursed-ocarina",
@@ -74,18 +77,21 @@
         "type": "hunting-horn",
         "name": "War Drum",
         "rarity": 3,
+        "craftable": true,
         "children": [
           {
             "slug": "war-drum-plus",
             "type": "hunting-horn",
             "name": "War Drum+",
             "rarity": 4,
+            "craftable": true,
             "children": [
               {
                 "slug": "war-bongo",
                 "type": "hunting-horn",
                 "name": "War Bongo",
                 "rarity": 6,
+                "craftable": true,
                 "children": [
                   {
                     "slug": "war-conga",
@@ -104,6 +110,7 @@
                         "type": "hunting-horn",
                         "name": "Jungle Bongo",
                         "rarity": 9,
+                        "craftable": true,
                         "children": [
                           {
                             "slug": "jungle-conga",
@@ -128,12 +135,14 @@
     "type": "hammer",
     "name": "Cyclo-Hammer",
     "rarity": 1,
+    "craftable": true,
     "children": [
       {
         "slug": "bone-horn",
         "type": "hunting-horn",
         "name": "Bone Horn",
         "rarity": 2,
+        "craftable": true,
         "children": [
           {
             "slug": "bone-horn-plus",
@@ -171,6 +180,7 @@
             "name": "Blessed Ocarina",
             "rarity": 5,
             "element": "poison",
+            "craftable": true,
             "children": [
               {
                 "slug": "cursed-ocarina",
@@ -199,6 +209,7 @@
     "type": "hammer",
     "name": "Bone Club",
     "rarity": 1,
+    "craftable": true,
     "children": [
       {
         "slug": "giaprey-balloon",
@@ -206,6 +217,7 @@
         "name": "Giaprey Balloon",
         "rarity": 2,
         "element": "ice",
+        "craftable": true,
         "children": [
           {
             "slug": "giaprey-balloon-plus",
@@ -268,6 +280,7 @@
         "type": "hunting-horn",
         "name": "Metal Bagpipe",
         "rarity": 2,
+        "craftable": true,
         "children": [
           {
             "slug": "great-bagpipe",
@@ -322,6 +335,7 @@
         "type": "hunting-horn",
         "name": "Sonic Glass",
         "rarity": 3,
+        "craftable": true,
         "children": [
           {
             "slug": "sonic-glass-plus",
@@ -341,6 +355,7 @@
                     "name": "Glass Royale",
                     "rarity": 9,
                     "element": "ice",
+                    "craftable": true,
                     "children": [
                       {
                         "slug": "queen-s-flute",
@@ -371,6 +386,7 @@
         "name": "Khezu Horn",
         "rarity": 3,
         "element": "thunder",
+        "craftable": true,
         "children": [
           {
             "slug": "khezu-horn-plus",
@@ -426,6 +442,7 @@
                 "name": "Purse Bop",
                 "rarity": 7,
                 "element": "thunder",
+                "craftable": true,
                 "children": []
               }
             ]
@@ -446,6 +463,7 @@
         "name": "Basarios Rock",
         "rarity": 4,
         "element": "fire",
+        "craftable": true,
         "children": [
           {
             "slug": "basarios-rock-mk-ii",
@@ -481,6 +499,7 @@
     "type": "hammer",
     "name": "Kut-Ku Pick",
     "rarity": 4,
+    "craftable": true,
     "children": [
       {
         "slug": "feather-whistle",
@@ -488,6 +507,7 @@
         "name": "Feather Whistle",
         "rarity": 6,
         "element": "sleep",
+        "craftable": true,
         "children": [
           {
             "slug": "hypno-whistle",
@@ -495,6 +515,7 @@
             "name": "Hypno Whistle",
             "rarity": 9,
             "element": "sleep",
+            "craftable": true,
             "children": [
               {
                 "slug": "hypno-slide-whistle",
@@ -521,6 +542,7 @@
         "name": "Shell Castanet",
         "rarity": 7,
         "element": "water",
+        "craftable": true,
         "children": [
           {
             "slug": "shell-castanet-plus",
@@ -567,6 +589,7 @@
         "type": "hunting-horn",
         "name": "Bronze Bell",
         "rarity": 5,
+        "craftable": true,
         "children": [
           {
             "slug": "gaoren-bell",
@@ -590,6 +613,7 @@
         "name": "Sakura Recorder",
         "rarity": 5,
         "element": "dragon",
+        "craftable": true,
         "children": [
           {
             "slug": "sakura-recorder-plus",
@@ -635,6 +659,7 @@
     "name": "Black Lute",
     "rarity": 5,
     "element": "dragon",
+    "craftable": true,
     "children": [
       {
         "slug": "fatalis-menace",
@@ -676,6 +701,7 @@
     "name": "Dragonwood Horn",
     "rarity": 5,
     "element": "paralysis",
+    "craftable": true,
     "children": [
       {
         "slug": "spirit-dragonwd-horn",
@@ -690,6 +716,7 @@
             "name": "AncientDrgnwoodFlute",
             "rarity": 9,
             "element": "paralysis",
+            "craftable": true,
             "children": [
               {
                 "slug": "divineancdrgnwdflute",
@@ -709,6 +736,7 @@
     "type": "hunting-horn",
     "name": "Striped Dragonga",
     "rarity": 5,
+    "craftable": true,
     "children": [
       {
         "slug": "tigrex-horn",
@@ -729,12 +757,14 @@
         "type": "hunting-horn",
         "name": "Hidden Tone",
         "rarity": 7,
+        "craftable": true,
         "children": [
           {
             "slug": "demon-s-darkflute",
             "type": "hunting-horn",
             "name": "Demon's Darkflute",
-            "rarity": 10
+            "rarity": 10,
+            "craftable": true
           }
         ]
       }
@@ -746,6 +776,7 @@
     "name": "Handmade Frog",
     "rarity": 6,
     "element": "water",
+    "craftable": true,
     "children": [
       {
         "slug": "handcrafted-frog",
@@ -768,6 +799,7 @@
         "name": "Wolf Shamisen",
         "rarity": 7,
         "element": "poison",
+        "craftable": true,
         "children": [
           {
             "slug": "crow-shamisen",
@@ -785,6 +817,7 @@
     "type": "hunting-horn",
     "name": "Akantor Horn",
     "rarity": 8,
+    "craftable": true,
     "children": [
       {
         "slug": "akantor-dark-melody",
@@ -799,6 +832,7 @@
     "type": "hammer",
     "name": "Blacksmith",
     "rarity": 9,
+    "craftable": true,
     "children": [
       {
         "slug": "lava-alphorn",
@@ -806,6 +840,7 @@
         "name": "Lava Alphorn",
         "rarity": 9,
         "element": "fire",
+        "craftable": true,
         "children": [
           {
             "slug": "volcano-alphorn",
@@ -823,78 +858,90 @@
     "type": "hunting-horn",
     "name": "Ukanlos Horned Flute",
     "rarity": 10,
-    "element": "ice"
+    "element": "ice",
+    "craftable": true
   },
   {
     "slug": "bone-horn-g",
     "type": "hunting-horn",
     "name": "Bone Horn G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "war-drum-g",
     "type": "hunting-horn",
     "name": "War Drum G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "great-bagpipe-g",
     "type": "hunting-horn",
     "name": "Great Bagpipe G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "khezu-flute-g",
     "type": "hunting-horn",
     "name": "Khezu Flute G",
     "rarity": 9,
-    "element": "thunder"
+    "element": "thunder",
+    "craftable": true
   },
   {
     "slug": "basarios-rock-g",
     "type": "hunting-horn",
     "name": "Basarios Rock G",
     "rarity": 9,
-    "element": "fire"
+    "element": "fire",
+    "craftable": true
   },
   {
     "slug": "glass-queen-g",
     "type": "hunting-horn",
     "name": "Glass Queen G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "heavy-bagpipe-g",
     "type": "hunting-horn",
     "name": "Heavy Bagpipe G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "velociprey-balloon-g",
     "type": "hunting-horn",
     "name": "Velociprey Balloon G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "giadrome-balloon-g",
     "type": "hunting-horn",
     "name": "Giadrome Balloon G",
     "rarity": 9,
-    "element": "ice"
+    "element": "ice",
+    "craftable": true
   },
   {
     "slug": "sakura-recorder-g",
     "type": "hunting-horn",
     "name": "Sakura Recorder G",
     "rarity": 10,
-    "element": "dragon"
+    "element": "dragon",
+    "craftable": true
   },
   {
     "slug": "spirit-dragonwd-horn-g",
     "type": "hunting-horn",
     "name": "Spirit Dragonwd Horn G",
     "rarity": 10,
-    "element": "paralysis"
+    "element": "paralysis",
+    "craftable": true
   }
 ]
 }

--- a/content/blacksmith/lance/map.json
+++ b/content/blacksmith/lance/map.json
@@ -5,12 +5,14 @@
     "type": "lance",
     "name": "Iron Lance",
     "rarity": 1,
+    "craftable": true,
     "children": [
       {
         "slug": "iron-lance-plus",
         "type": "lance",
         "name": "Iron Lance+",
         "rarity": 1,
+        "craftable": true,
         "children": [
           {
             "slug": "steel-lance",
@@ -23,6 +25,7 @@
                 "type": "lance",
                 "name": "Paladin Lance",
                 "rarity": 2,
+                "craftable": true,
                 "children": [
                   {
                     "slug": "rampart",
@@ -36,6 +39,7 @@
                         "name": "Growling Wyvern",
                         "rarity": 4,
                         "element": "dragon",
+                        "craftable": true,
                         "children": [
                           {
                             "slug": "roaring-wyvern",
@@ -49,6 +53,7 @@
                                 "type": "lance",
                                 "name": "SanctionedDrillLance",
                                 "rarity": 9,
+                                "craftable": true,
                                 "children": [
                                   {
                                     "slug": "gravedigger",
@@ -65,6 +70,7 @@
                             "type": "lance",
                             "name": "Knight Lance",
                             "rarity": 6,
+                            "craftable": true,
                             "children": [
                               {
                                 "slug": "knight-spear",
@@ -84,6 +90,7 @@
                                         "name": "Sadalsuud",
                                         "rarity": 9,
                                         "element": "water",
+                                        "craftable": true,
                                         "children": [
                                           {
                                             "slug": "sadalmelek",
@@ -114,6 +121,7 @@
                                         "type": "gunlance",
                                         "name": "Ancient Destroyer",
                                         "rarity": 9,
+                                        "craftable": true,
                                         "children": []
                                       },
                                       {
@@ -122,6 +130,7 @@
                                         "name": "Spark Plug",
                                         "rarity": 9,
                                         "element": "thunder",
+                                        "craftable": true,
                                         "children": [
                                           {
                                             "slug": "thunderbugshocklance",
@@ -142,6 +151,7 @@
                                 "name": "Aqua Spear",
                                 "rarity": 6,
                                 "element": "water",
+                                "craftable": true,
                                 "children": [
                                   {
                                     "slug": "aqua-spear-plus",
@@ -189,6 +199,7 @@
                                 "name": "Cold Icicle",
                                 "rarity": 6,
                                 "element": "ice",
+                                "craftable": true,
                                 "children": [
                                   {
                                     "slug": "frost-icicle",
@@ -214,6 +225,7 @@
                                 "name": "Feather Gunlance",
                                 "rarity": 6,
                                 "element": "sleep",
+                                "craftable": true,
                                 "children": []
                               }
                             ]
@@ -226,6 +238,7 @@
                         "name": "Gatling Lance",
                         "rarity": 4,
                         "element": "fire",
+                        "craftable": true,
                         "children": [
                           {
                             "slug": "gatling-lance-plus",
@@ -251,6 +264,7 @@
                         "name": "Naag Serpentblade",
                         "rarity": 4,
                         "element": "poison",
+                        "craftable": true,
                         "children": [
                           {
                             "slug": "devta-serpentblade",
@@ -308,6 +322,7 @@
                     "name": "Lullaby Spear",
                     "rarity": 3,
                     "element": "sleep",
+                    "craftable": true,
                     "children": [
                       {
                         "slug": "requiem-spear",
@@ -338,6 +353,7 @@
                         "name": "Venom Lance",
                         "rarity": 4,
                         "element": "poison",
+                        "craftable": true,
                         "children": [
                           {
                             "slug": "basarios-venom-spear",
@@ -424,6 +440,7 @@
                         "name": "Thunderspear",
                         "rarity": 5,
                         "element": "thunder",
+                        "craftable": true,
                         "children": [
                           {
                             "slug": "thunderlance",
@@ -456,6 +473,7 @@
         "type": "gunlance",
         "name": "Iron Gunlance",
         "rarity": 1,
+        "craftable": true,
         "children": []
       },
       {
@@ -464,6 +482,7 @@
         "name": "Snow Gunlance",
         "rarity": 2,
         "element": "ice",
+        "craftable": true,
         "children": []
       }
     ]
@@ -473,6 +492,7 @@
     "type": "lance",
     "name": "Longhorn",
     "rarity": 1,
+    "craftable": true,
     "children": [
       {
         "slug": "longhorn-plus",
@@ -485,18 +505,21 @@
             "type": "lance",
             "name": "Long Tusk",
             "rarity": 1,
+            "craftable": true,
             "children": [
               {
                 "slug": "barbaroi-tusk",
                 "type": "lance",
                 "name": "Barbaroi Tusk",
                 "rarity": 2,
+                "craftable": true,
                 "children": [
                   {
                     "slug": "ogre-tusk",
                     "type": "lance",
                     "name": "Ogre Tusk",
                     "rarity": 3,
+                    "craftable": true,
                     "children": [
                       {
                         "slug": "great-ogre-tusk",
@@ -509,6 +532,7 @@
                         "type": "lance",
                         "name": "Hard Bone Lance",
                         "rarity": 6,
+                        "craftable": true,
                         "children": [
                           {
                             "slug": "hard-bone-lance-plus",
@@ -541,6 +565,7 @@
                                     "type": "gunlance",
                                     "name": "Heavy Bone Gunlance",
                                     "rarity": 9,
+                                    "craftable": true,
                                     "children": []
                                   }
                                 ]
@@ -551,6 +576,7 @@
                                 "name": "Demon Lance",
                                 "rarity": 7,
                                 "element": "thunder",
+                                "craftable": true,
                                 "children": [
                                   {
                                     "slug": "great-demon-lance",
@@ -576,6 +602,7 @@
                                 "name": "Full Voltage",
                                 "rarity": 7,
                                 "element": "thunder",
+                                "craftable": true,
                                 "children": []
                               }
                             ]
@@ -590,6 +617,7 @@
                     "name": "Incessant Raven",
                     "rarity": 5,
                     "element": "poison",
+                    "craftable": true,
                     "children": [
                       {
                         "slug": "incessant-wolf",
@@ -617,6 +645,7 @@
                 "name": "Crimson Lance",
                 "rarity": 3,
                 "element": "fire",
+                "craftable": true,
                 "children": [
                   {
                     "slug": "crimson-war-pike",
@@ -705,6 +734,7 @@
                 "type": "lance",
                 "name": "Bone Claw Lance",
                 "rarity": 3,
+                "craftable": true,
                 "children": [
                   {
                     "slug": "bone-claw-lance-plus",
@@ -717,6 +747,7 @@
                         "type": "gunlance",
                         "name": "Scissor Gunlance",
                         "rarity": 6,
+                        "craftable": true,
                         "children": []
                       },
                       {
@@ -730,6 +761,7 @@
                             "type": "lance",
                             "name": "Carmine Stinger",
                             "rarity": 9,
+                            "craftable": true,
                             "children": [
                               {
                                 "slug": "shish-kabob-stick",
@@ -744,6 +776,7 @@
                             "type": "lance",
                             "name": "Shell Claw Lance",
                             "rarity": 9,
+                            "craftable": true,
                             "children": [
                               {
                                 "slug": "gianthermitaurlance",
@@ -782,6 +815,7 @@
                             "type": "lance",
                             "name": "Carmine Stinger",
                             "rarity": 9,
+                            "craftable": true,
                             "children": [
                               {
                                 "slug": "shish-kabob-stick",
@@ -796,6 +830,7 @@
                             "type": "lance",
                             "name": "Shell Claw Lance",
                             "rarity": 9,
+                            "craftable": true,
                             "children": [
                               {
                                 "slug": "gianthermitaurlance",
@@ -861,6 +896,7 @@
         "type": "lance",
         "name": "Wild Bone Lance",
         "rarity": 2,
+        "craftable": true,
         "children": [
           {
             "slug": "wild-bone-lance-plus",
@@ -880,6 +916,7 @@
                 "name": "Red Tail",
                 "rarity": 3,
                 "element": "fire",
+                "craftable": true,
                 "children": [
                   {
                     "slug": "spear-of-prominence",
@@ -922,6 +959,7 @@
             "type": "lance",
             "name": "Fragrance",
             "rarity": 2,
+            "craftable": true,
             "children": [
               {
                 "slug": "fragrance-plus",
@@ -948,6 +986,7 @@
     "type": "lance",
     "name": "Rusted Lance",
     "rarity": 1,
+    "craftable": true,
     "children": [
       {
         "slug": "tarnished-lance",
@@ -1005,6 +1044,7 @@
     "name": "Native Spear",
     "rarity": 3,
     "element": "poison",
+    "craftable": true,
     "children": [
       {
         "slug": "primal-spear",
@@ -1021,6 +1061,7 @@
     "name": "Vacuum Striker",
     "rarity": 3,
     "element": "water",
+    "craftable": true,
     "children": [
       {
         "slug": "hyper-vacuum",
@@ -1036,6 +1077,7 @@
     "type": "lance",
     "name": "Black Belt Lance",
     "rarity": 4,
+    "craftable": true,
     "children": [
       {
         "slug": "expert-lance",
@@ -1061,6 +1103,7 @@
     "name": "Black Lance",
     "rarity": 5,
     "element": "dragon",
+    "craftable": true,
     "children": [
       {
         "slug": "black-dragon-spear",
@@ -1101,6 +1144,7 @@
     "type": "lance",
     "name": "Tiger Stinger",
     "rarity": 5,
+    "craftable": true,
     "children": [
       {
         "slug": "tigrex-lance",
@@ -1121,12 +1165,14 @@
         "type": "lance",
         "name": "Hidden Stinger",
         "rarity": 7,
+        "craftable": true,
         "children": [
           {
             "slug": "black-rain-darklance",
             "type": "lance",
             "name": "Black Rain Darklance",
-            "rarity": 10
+            "rarity": 10,
+            "craftable": true
           }
         ]
       }
@@ -1138,6 +1184,7 @@
     "name": "Vermillion Rim",
     "rarity": 5,
     "element": "dragon",
+    "craftable": true,
     "children": [
       {
         "slug": "dragonic-rim",
@@ -1180,6 +1227,7 @@
     "type": "lance",
     "name": "Worn Spear",
     "rarity": 6,
+    "craftable": true,
     "children": [
       {
         "slug": "weathered-spear",
@@ -1241,6 +1289,7 @@
         "type": "lance",
         "name": "Shell Claw Lance",
         "rarity": 9,
+        "craftable": true,
         "children": [
           {
             "slug": "gianthermitaurlance",
@@ -1257,240 +1306,277 @@
     "type": "lance",
     "name": "Ukanlos Calamity",
     "rarity": 10,
-    "element": "ice"
+    "element": "ice",
+    "craftable": true
   },
   {
     "slug": "iron-lance-g",
     "type": "lance",
     "name": "Iron Lance G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "long-tusk-g",
     "type": "lance",
     "name": "Long Tusk G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "tarnished-lance-g",
     "type": "lance",
     "name": "Tarnished Lance G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "spiked-spear-g",
     "type": "lance",
     "name": "Spiked Spear G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "rampart-g",
     "type": "lance",
     "name": "Rampart G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "valhalla-g",
     "type": "lance",
     "name": "Valhalla G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "fragrance-g",
     "type": "lance",
     "name": "Fragrance G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "requiem-spear-g",
     "type": "lance",
     "name": "Requiem Spear G",
     "rarity": 9,
-    "element": "sleep"
+    "element": "sleep",
+    "craftable": true
   },
   {
     "slug": "dark-spear-g",
     "type": "lance",
     "name": "Dark Spear G",
     "rarity": 9,
-    "element": "paralysis"
+    "element": "paralysis",
+    "craftable": true
   },
   {
     "slug": "bulldrome-spear-g",
     "type": "lance",
     "name": "Bulldrome Spear G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "bone-claw-lance-g",
     "type": "lance",
     "name": "Bone Claw Lance G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "trident-g",
     "type": "lance",
     "name": "Trident G",
     "rarity": 9,
-    "element": "paralysis"
+    "element": "paralysis",
+    "craftable": true
   },
   {
     "slug": "gatling-lance-g",
     "type": "lance",
     "name": "Gatling Lance G",
     "rarity": 9,
-    "element": "fire"
+    "element": "fire",
+    "craftable": true
   },
   {
     "slug": "venom-lance-g",
     "type": "lance",
     "name": "Venom Lance G",
     "rarity": 9,
-    "element": "poison"
+    "element": "poison",
+    "craftable": true
   },
   {
     "slug": "crimson-war-pike-g",
     "type": "lance",
     "name": "Crimson War Pike G",
     "rarity": 9,
-    "element": "fire"
+    "element": "fire",
+    "craftable": true
   },
   {
     "slug": "diablo-spear-g",
     "type": "lance",
     "name": "Diablo Spear G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "native-spear-g",
     "type": "lance",
     "name": "Native Spear G",
     "rarity": 9,
-    "element": "poison"
+    "element": "poison",
+    "craftable": true
   },
   {
     "slug": "black-belt-lance-g",
     "type": "lance",
     "name": "Black Belt Lance G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "undertaker-g",
     "type": "lance",
     "name": "Undertaker G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "knight-spear-g",
     "type": "lance",
     "name": "Knight Spear G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "hard-bone-lance-g",
     "type": "lance",
     "name": "Hard Bone Lance G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "roaring-wyvern-g",
     "type": "lance",
     "name": "Roaring Wyvern G",
     "rarity": 9,
-    "element": "dragon"
+    "element": "dragon",
+    "craftable": true
   },
   {
     "slug": "great-ogre-tusk-g",
     "type": "lance",
     "name": "Great Ogre Tusk G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "barbarian-tusk-g",
     "type": "lance",
     "name": "Barbarian Tusk G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "noble-fragrance-g",
     "type": "lance",
     "name": "Noble Fragrance G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "hyper-vacuum-g",
     "type": "lance",
     "name": "Hyper Vacuum G",
     "rarity": 9,
-    "element": "water"
+    "element": "water",
+    "craftable": true
   },
   {
     "slug": "aqua-spear-g",
     "type": "lance",
     "name": "Aqua Spear G",
     "rarity": 9,
-    "element": "water"
+    "element": "water",
+    "craftable": true
   },
   {
     "slug": "emerald-spear-g",
     "type": "lance",
     "name": "Emerald Spear G",
     "rarity": 9,
-    "element": "water"
+    "element": "water",
+    "craftable": true
   },
   {
     "slug": "grayburg-javelin-g",
     "type": "lance",
     "name": "Grayburg Javelin G",
-    "rarity": 10
+    "rarity": 10,
+    "craftable": true
   },
   {
     "slug": "sanctioned-gunlance-g",
     "type": "lance",
     "name": "Sanctioned Gunlance G",
     "rarity": 10,
-    "element": "fire"
+    "element": "fire",
+    "craftable": true
   },
   {
     "slug": "ceanataur-piercer-g",
     "type": "lance",
     "name": "Ceanataur Piercer G",
-    "rarity": 10
+    "rarity": 10,
+    "craftable": true
   },
   {
     "slug": "ceramic-blos-lance-g",
     "type": "lance",
     "name": "Ceramic Blos Lance G",
     "rarity": 10,
-    "element": "water"
+    "element": "water",
+    "craftable": true
   },
   {
     "slug": "gravios-spear-g",
     "type": "lance",
     "name": "Gravios Spear G",
     "rarity": 10,
-    "element": "poison"
+    "element": "poison",
+    "craftable": true
   },
   {
     "slug": "blackgraviousspear-g",
     "type": "lance",
     "name": "BlackGraviousSpear G",
     "rarity": 10,
-    "element": "fire"
+    "element": "fire",
+    "craftable": true
   },
   {
     "slug": "spear-of-prominence-g",
     "type": "lance",
     "name": "Spear of Prominence G",
     "rarity": 10,
-    "element": "fire"
+    "element": "fire",
+    "craftable": true
   },
   {
     "slug": "sealed-dragonlance-g",
     "type": "lance",
     "name": "Sealed Dragonlance G",
     "rarity": 10,
-    "element": "dragon"
+    "element": "dragon",
+    "craftable": true
   }
 ]
 }

--- a/content/blacksmith/light-bowgun/map.json
+++ b/content/blacksmith/light-bowgun/map.json
@@ -4,799 +4,932 @@
     "slug": "shooter-s-barrel",
     "type": "light-bowgun",
     "name": "Shooter's Barrel",
-    "rarity": 1
+    "rarity": 1,
+    "craftable": true
   },
   {
     "slug": "chain-blitz",
     "type": "light-bowgun",
     "name": "Chain Blitz",
-    "rarity": 1
+    "rarity": 1,
+    "craftable": true
   },
   {
     "slug": "shotgun-azure",
     "type": "light-bowgun",
     "name": "Shotgun (Azure)",
-    "rarity": 3
+    "rarity": 3,
+    "craftable": true
   },
   {
     "slug": "shotgun-white",
     "type": "light-bowgun",
     "name": "Shotgun (White)",
-    "rarity": 3
+    "rarity": 3,
+    "craftable": true
   },
   {
     "slug": "shotgun-green",
     "type": "light-bowgun",
     "name": "Shotgun (Green)",
-    "rarity": 3
+    "rarity": 3,
+    "craftable": true
   },
   {
     "slug": "desert-storm",
     "type": "light-bowgun",
     "name": "Desert Storm",
-    "rarity": 3
+    "rarity": 3,
+    "craftable": true
   },
   {
     "slug": "maelstrom",
     "type": "light-bowgun",
     "name": "Maelstrom",
-    "rarity": 3
+    "rarity": 3,
+    "craftable": true
   },
   {
     "slug": "shotgun-blood",
     "type": "light-bowgun",
     "name": "Shotgun (Blood)",
-    "rarity": 3
+    "rarity": 3,
+    "craftable": true
   },
   {
     "slug": "tail-string",
     "type": "light-bowgun",
     "name": "Tail String",
-    "rarity": 3
+    "rarity": 3,
+    "craftable": true
   },
   {
     "slug": "assault-conga",
     "type": "light-bowgun",
     "name": "Assault Conga",
-    "rarity": 3
+    "rarity": 3,
+    "craftable": true
   },
   {
     "slug": "jade-storm",
     "type": "light-bowgun",
     "name": "Jade Storm",
-    "rarity": 3
+    "rarity": 3,
+    "craftable": true
   },
   {
     "slug": "lobster-gun",
     "type": "light-bowgun",
     "name": "Lobster Gun",
-    "rarity": 3
+    "rarity": 3,
+    "craftable": true
   },
   {
     "slug": "angel-parasol",
     "type": "light-bowgun",
     "name": "Angel Parasol",
-    "rarity": 3
+    "rarity": 3,
+    "craftable": true
   },
   {
     "slug": "kut-ku-anger",
     "type": "light-bowgun",
     "name": "Kut-Ku Anger",
-    "rarity": 3
+    "rarity": 3,
+    "craftable": true
   },
   {
     "slug": "kut-ku-rage",
     "type": "light-bowgun",
     "name": "Kut-Ku Rage",
-    "rarity": 3
+    "rarity": 3,
+    "craftable": true
   },
   {
     "slug": "grenade-launcher",
     "type": "light-bowgun",
     "name": "Grenade Launcher",
-    "rarity": 4
+    "rarity": 4,
+    "craftable": true
   },
   {
     "slug": "sandfall",
     "type": "light-bowgun",
     "name": "Sandfall",
-    "rarity": 4
+    "rarity": 4,
+    "craftable": true
   },
   {
     "slug": "sakura-parasol",
     "type": "light-bowgun",
     "name": "Sakura Parasol",
-    "rarity": 4
+    "rarity": 4,
+    "craftable": true
   },
   {
     "slug": "tail-string-plus",
     "type": "light-bowgun",
     "name": "Tail String+",
-    "rarity": 4
+    "rarity": 4,
+    "craftable": true
   },
   {
     "slug": "valkyrie-fire",
     "type": "light-bowgun",
     "name": "Valkyrie Fire",
-    "rarity": 4
+    "rarity": 4,
+    "craftable": true
   },
   {
     "slug": "spartacus-fire",
     "type": "light-bowgun",
     "name": "Spartacus Fire",
-    "rarity": 4
+    "rarity": 4,
+    "craftable": true
   },
   {
     "slug": "titan-launcher",
     "type": "light-bowgun",
     "name": "Titan Launcher",
-    "rarity": 4
+    "rarity": 4,
+    "craftable": true
   },
   {
     "slug": "uranos-grenade",
     "type": "light-bowgun",
     "name": "Uranos Grenade",
-    "rarity": 4
+    "rarity": 4,
+    "craftable": true
   },
   {
     "slug": "tigrex-tank",
     "type": "light-bowgun",
     "name": "Tigrex Tank",
-    "rarity": 4
+    "rarity": 4,
+    "craftable": true
   },
   {
     "slug": "demonlock",
     "type": "light-bowgun",
     "name": "Demonlock",
-    "rarity": 5
+    "rarity": 5,
+    "craftable": true
   },
   {
     "slug": "felyne-ragdoll",
     "type": "light-bowgun",
     "name": "Felyne Ragdoll",
-    "rarity": 5
+    "rarity": 5,
+    "craftable": true
   },
   {
     "slug": "melynx-ragdoll",
     "type": "light-bowgun",
     "name": "Melynx Ragdoll",
-    "rarity": 5
+    "rarity": 5,
+    "craftable": true
   },
   {
     "slug": "dummy-amezari-bowgun",
     "type": "light-bowgun",
     "name": "dummy (Amezari Bowgun)",
-    "rarity": 5
+    "rarity": 5,
+    "craftable": true
   },
   {
     "slug": "blessed-lamp",
     "type": "light-bowgun",
     "name": "Blessed Lamp",
-    "rarity": 5
+    "rarity": 5,
+    "craftable": true
   },
   {
     "slug": "black-belt-bowgun",
     "type": "light-bowgun",
     "name": "Black Belt Bowgun",
-    "rarity": 5
+    "rarity": 5,
+    "craftable": true
   },
   {
     "slug": "black-parasol",
     "type": "light-bowgun",
     "name": "Black Parasol",
-    "rarity": 5
+    "rarity": 5,
+    "craftable": true
   },
   {
     "slug": "raven-do",
     "type": "light-bowgun",
     "name": "Raven Do",
-    "rarity": 5
+    "rarity": 5,
+    "craftable": true
   },
   {
     "slug": "valkyrie-heart",
     "type": "light-bowgun",
     "name": "Valkyrie Heart",
-    "rarity": 5
+    "rarity": 5,
+    "craftable": true
   },
   {
     "slug": "azure-sakura",
     "type": "light-bowgun",
     "name": "Azure Sakura",
-    "rarity": 5
+    "rarity": 5,
+    "craftable": true
   },
   {
     "slug": "spartacus-soul",
     "type": "light-bowgun",
     "name": "Spartacus Soul",
-    "rarity": 5
+    "rarity": 5,
+    "craftable": true
   },
   {
     "slug": "aqua-blade-shower",
     "type": "light-bowgun",
     "name": "Aqua Blade Shower",
-    "rarity": 6
+    "rarity": 6,
+    "craftable": true
   },
   {
     "slug": "maelstrom-plus",
     "type": "light-bowgun",
     "name": "Maelstrom+",
-    "rarity": 6
+    "rarity": 6,
+    "craftable": true
   },
   {
     "slug": "green-blade-shower",
     "type": "light-bowgun",
     "name": "Green Blade Shower",
-    "rarity": 6
+    "rarity": 6,
+    "craftable": true
   },
   {
     "slug": "grenade-launcher-plus",
     "type": "light-bowgun",
     "name": "Grenade Launcher+",
-    "rarity": 6
+    "rarity": 6,
+    "craftable": true
   },
   {
     "slug": "desert-tempest",
     "type": "light-bowgun",
     "name": "Desert Tempest",
-    "rarity": 6
+    "rarity": 6,
+    "craftable": true
   },
   {
     "slug": "hornet-gun",
     "type": "light-bowgun",
     "name": "HorNet Gun",
-    "rarity": 6
+    "rarity": 6,
+    "craftable": true
   },
   {
     "slug": "crimson-blade-shower",
     "type": "light-bowgun",
     "name": "Crimson Blade Shower",
-    "rarity": 6
+    "rarity": 6,
+    "craftable": true
   },
   {
     "slug": "king-lobster-gun",
     "type": "light-bowgun",
     "name": "King Lobster Gun",
-    "rarity": 6
+    "rarity": 6,
+    "craftable": true
   },
   {
     "slug": "valkyrie-blaze",
     "type": "light-bowgun",
     "name": "Valkyrie Blaze",
-    "rarity": 6
+    "rarity": 6,
+    "craftable": true
   },
   {
     "slug": "great-crossbow-gun",
     "type": "light-bowgun",
     "name": "Great Crossbow Gun",
-    "rarity": 6
+    "rarity": 6,
+    "craftable": true
   },
   {
     "slug": "assault-conga-plus",
     "type": "light-bowgun",
     "name": "Assault Conga+",
-    "rarity": 6
+    "rarity": 6,
+    "craftable": true
   },
   {
     "slug": "spartacus-blaze",
     "type": "light-bowgun",
     "name": "Spartacus Blaze",
-    "rarity": 6
+    "rarity": 6,
+    "craftable": true
   },
   {
     "slug": "tail-catapult-plus",
     "type": "light-bowgun",
     "name": "Tail Catapult+",
-    "rarity": 6
+    "rarity": 6,
+    "craftable": true
   },
   {
     "slug": "titan-launcher-plus",
     "type": "light-bowgun",
     "name": "Titan Launcher+",
-    "rarity": 6
+    "rarity": 6,
+    "craftable": true
   },
   {
     "slug": "tigrex-wargun",
     "type": "light-bowgun",
     "name": "Tigrex Wargun",
-    "rarity": 6
+    "rarity": 6,
+    "craftable": true
   },
   {
     "slug": "hidden-gaze",
     "type": "light-bowgun",
     "name": "Hidden Gaze",
-    "rarity": 7
+    "rarity": 7,
+    "craftable": true
   },
   {
     "slug": "bullet-storm",
     "type": "light-bowgun",
     "name": "Bullet Storm",
-    "rarity": 7
+    "rarity": 7,
+    "craftable": true
   },
   {
     "slug": "jade-tempest",
     "type": "light-bowgun",
     "name": "Jade Tempest",
-    "rarity": 7
+    "rarity": 7,
+    "craftable": true
   },
   {
     "slug": "sandfall-plus",
     "type": "light-bowgun",
     "name": "Sandfall+",
-    "rarity": 7
+    "rarity": 7,
+    "craftable": true
   },
   {
     "slug": "peach-parasol",
     "type": "light-bowgun",
     "name": "Peach Parasol",
-    "rarity": 7
+    "rarity": 7,
+    "craftable": true
   },
   {
     "slug": "chronos-grenade",
     "type": "light-bowgun",
     "name": "Chronos Grenade",
-    "rarity": 7
+    "rarity": 7,
+    "craftable": true
   },
   {
     "slug": "island-of-the-gods",
     "type": "light-bowgun",
     "name": "Island of the Gods",
-    "rarity": 8
+    "rarity": 8,
+    "craftable": true
   },
   {
     "slug": "felyne-helldoll",
     "type": "light-bowgun",
     "name": "Felyne Helldoll",
-    "rarity": 8
+    "rarity": 8,
+    "craftable": true
   },
   {
     "slug": "melynx-helldoll",
     "type": "light-bowgun",
     "name": "Melynx Helldoll",
-    "rarity": 8
+    "rarity": 8,
+    "craftable": true
   },
   {
     "slug": "shakalaka-prized-bow",
     "type": "light-bowgun",
     "name": "Shakalaka Prized Bow",
-    "rarity": 8
+    "rarity": 8,
+    "craftable": true
   },
   {
     "slug": "expert-bowgun",
     "type": "light-bowgun",
     "name": "Expert Bowgun",
-    "rarity": 8
+    "rarity": 8,
+    "craftable": true
   },
   {
     "slug": "valkyrie-heart-plus",
     "type": "light-bowgun",
     "name": "Valkyrie Heart+",
-    "rarity": 8
+    "rarity": 8,
+    "craftable": true
   },
   {
     "slug": "crimson-blue",
     "type": "light-bowgun",
     "name": "Crimson Blue",
-    "rarity": 8
+    "rarity": 8,
+    "craftable": true
   },
   {
     "slug": "cursed-lamp",
     "type": "light-bowgun",
     "name": "Cursed Lamp",
-    "rarity": 8
+    "rarity": 8,
+    "craftable": true
   },
   {
     "slug": "spartacus-soul-plus",
     "type": "light-bowgun",
     "name": "Spartacus Soul+",
-    "rarity": 8
+    "rarity": 8,
+    "craftable": true
   },
   {
     "slug": "supreme-azure-sakura",
     "type": "light-bowgun",
     "name": "Supreme Azure Sakura",
-    "rarity": 8
+    "rarity": 8,
+    "craftable": true
   },
   {
     "slug": "gold-valkyrie",
     "type": "light-bowgun",
     "name": "Gold Valkyrie",
-    "rarity": 8
+    "rarity": 8,
+    "craftable": true
   },
   {
     "slug": "wolf-do",
     "type": "light-bowgun",
     "name": "Wolf Do",
-    "rarity": 8
+    "rarity": 8,
+    "craftable": true
   },
   {
     "slug": "silver-spartacus",
     "type": "light-bowgun",
     "name": "Silver Spartacus",
-    "rarity": 8
+    "rarity": 8,
+    "craftable": true
   },
   {
     "slug": "profusion",
     "type": "light-bowgun",
     "name": "Profusion",
-    "rarity": 8
+    "rarity": 8,
+    "craftable": true
   },
   {
     "slug": "dark-parasol",
     "type": "light-bowgun",
     "name": "Dark Parasol",
-    "rarity": 8
+    "rarity": 8,
+    "craftable": true
   },
   {
     "slug": "fire-wrath",
     "type": "light-bowgun",
     "name": "Fire Wrath",
-    "rarity": 8
+    "rarity": 8,
+    "craftable": true
   },
   {
     "slug": "rajang-barrage",
     "type": "light-bowgun",
     "name": "Rajang Barrage",
-    "rarity": 8
+    "rarity": 8,
+    "craftable": true
   },
   {
     "slug": "hi-chain-blitz",
     "type": "light-bowgun",
     "name": "Hi Chain Blitz",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "nebula-storm",
     "type": "light-bowgun",
     "name": "Nebula Storm",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "jade-typhoon",
     "type": "light-bowgun",
     "name": "Jade Typhoon",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "royal-lobster-gun",
     "type": "light-bowgun",
     "name": "Royal Lobster Gun",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "combat-conga",
     "type": "light-bowgun",
     "name": "Combat Conga",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "jungle-assault",
     "type": "light-bowgun",
     "name": "Jungle Assault",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "heartfelt-cast",
     "type": "light-bowgun",
     "name": "Heartfelt Cast",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "kut-ku-counterattack",
     "type": "light-bowgun",
     "name": "Kut-Ku Counterattack",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "kut-ku-barrage",
     "type": "light-bowgun",
     "name": "Kut-Ku Barrage",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "shotgun-snake",
     "type": "light-bowgun",
     "name": "Shotgun (Snake)",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "grenade-revolver",
     "type": "light-bowgun",
     "name": "Grenade Revolver",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "fierce-moss-green",
     "type": "light-bowgun",
     "name": "Fierce Moss Green",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "fierce-wine-red",
     "type": "light-bowgun",
     "name": "Fierce Wine Red",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "tail-launcher",
     "type": "light-bowgun",
     "name": "Tail Launcher",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "sakura-semi-auto",
     "type": "light-bowgun",
     "name": "Sakura Semi-Auto",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "azure-semi-auto",
     "type": "light-bowgun",
     "name": "Azure Semi-Auto",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "lava-storm",
     "type": "light-bowgun",
     "name": "Lava Storm",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "desert-tail",
     "type": "light-bowgun",
     "name": "Desert Tail",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "titan-panzer",
     "type": "light-bowgun",
     "name": "Titan Panzer",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "hexed-shaka-bow",
     "type": "light-bowgun",
     "name": "Hexed Shaka Bow",
-    "rarity": 10
+    "rarity": 10,
+    "craftable": true
   },
   {
     "slug": "owl-s-eye-darkbow",
     "type": "light-bowgun",
     "name": "Owl's Eye Darkbow",
-    "rarity": 10
+    "rarity": 10,
+    "craftable": true
   },
   {
     "slug": "warrior-s-bowgun",
     "type": "light-bowgun",
     "name": "Warrior's Bowgun",
-    "rarity": 10
+    "rarity": 10,
+    "craftable": true
   },
   {
     "slug": "promenade",
     "type": "light-bowgun",
     "name": "Promenade",
-    "rarity": 10
+    "rarity": 10,
+    "craftable": true
   },
   {
     "slug": "pollination",
     "type": "light-bowgun",
     "name": "Pollination",
-    "rarity": 10
+    "rarity": 10,
+    "craftable": true
   },
   {
     "slug": "mythical-three-horn",
     "type": "light-bowgun",
     "name": "Mythical Three-Horn",
-    "rarity": 10
+    "rarity": 10,
+    "craftable": true
   },
   {
     "slug": "crow-do",
     "type": "light-bowgun",
     "name": "Crow Do",
-    "rarity": 10
+    "rarity": 10,
+    "craftable": true
   },
   {
     "slug": "gold-semi-auto",
     "type": "light-bowgun",
     "name": "Gold Semi-Auto ",
-    "rarity": 10
+    "rarity": 10,
+    "craftable": true
   },
   {
     "slug": "silver-semi-auto",
     "type": "light-bowgun",
     "name": "Silver Semi-Auto",
-    "rarity": 10
+    "rarity": 10,
+    "craftable": true
   },
   {
     "slug": "prosperity",
     "type": "light-bowgun",
     "name": "Prosperity",
-    "rarity": 10
+    "rarity": 10,
+    "craftable": true
   },
   {
     "slug": "genie-s-lamp",
     "type": "light-bowgun",
     "name": "Genie's Lamp",
-    "rarity": 10
+    "rarity": 10,
+    "craftable": true
   },
   {
     "slug": "chronos-panzer",
     "type": "light-bowgun",
     "name": "Chronos Panzer",
-    "rarity": 10
+    "rarity": 10,
+    "craftable": true
   },
   {
     "slug": "engravedfirewyvnbow",
     "type": "light-bowgun",
     "name": "EngravedFireWyvnBow",
-    "rarity": 10
+    "rarity": 10,
+    "craftable": true
   },
   {
     "slug": "ten-thousand-volts",
     "type": "light-bowgun",
     "name": "Ten-Thousand Volts",
-    "rarity": 10
+    "rarity": 10,
+    "craftable": true
   },
   {
     "slug": "absolute-bow",
     "type": "light-bowgun",
     "name": "Absolute Bow",
-    "rarity": 10
+    "rarity": 10,
+    "craftable": true
   },
   {
     "slug": "tigrex-wargun-plus",
     "type": "light-bowgun",
     "name": "Tigrex Wargun+",
-    "rarity": 10
+    "rarity": 10,
+    "craftable": true
   },
   {
     "slug": "ukanlos-flame-bow",
     "type": "light-bowgun",
     "name": "Ukanlos Flame Bow",
-    "rarity": 10
+    "rarity": 10,
+    "craftable": true
   },
   {
     "slug": "crossbow-gun-g",
     "type": "light-bowgun",
     "name": "Crossbow Gun G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "hornet-gun-g",
     "type": "light-bowgun",
     "name": "HorNet Gun G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "shotgun-white-g",
     "type": "light-bowgun",
     "name": "Shotgun (White) G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "shotgun-azure-g",
     "type": "light-bowgun",
     "name": "Shotgun (Azure) G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "shotgun-emerald-g",
     "type": "light-bowgun",
     "name": "Shotgun (Emerald) G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "shotgun-blood-g",
     "type": "light-bowgun",
     "name": "Shotgun (Blood) G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "desert-tempest-g",
     "type": "light-bowgun",
     "name": "Desert Tempest G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "sandfall-g",
     "type": "light-bowgun",
     "name": "Sandfall G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "maelstrom-g",
     "type": "light-bowgun",
     "name": "Maelstrom G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "jade-typhoon-g",
     "type": "light-bowgun",
     "name": "Jade Typhoon G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "king-lobster-gun-g",
     "type": "light-bowgun",
     "name": "King Lobster Gun G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "angel-parasol-g",
     "type": "light-bowgun",
     "name": "Angel Parasol G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "peach-parasol-g",
     "type": "light-bowgun",
     "name": "Peach Parasol G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "combat-conga-g",
     "type": "light-bowgun",
     "name": "Combat Conga G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "jungle-assault-g",
     "type": "light-bowgun",
     "name": "Jungle Assault G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "heartfelt-cast-g",
     "type": "light-bowgun",
     "name": "Heartfelt Cast G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "kut-ku-counteratk-g",
     "type": "light-bowgun",
     "name": "Kut-Ku Counteratk G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "kut-ku-barrage-g",
     "type": "light-bowgun",
     "name": "Kut-Ku Barrage G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "island-of-the-gods-g",
     "type": "light-bowgun",
     "name": "Island of the Gods G",
-    "rarity": 10
+    "rarity": 10,
+    "craftable": true
   },
   {
     "slug": "felyne-helldoll-g",
     "type": "light-bowgun",
     "name": "Felyne Helldoll G",
-    "rarity": 10
+    "rarity": 10,
+    "craftable": true
   },
   {
     "slug": "melynx-helldoll-g",
     "type": "light-bowgun",
     "name": "Melynx Helldoll G",
-    "rarity": 10
+    "rarity": 10,
+    "craftable": true
   },
   {
     "slug": "hexed-shaka-bow-g",
     "type": "light-bowgun",
     "name": "Hexed Shaka Bow G",
-    "rarity": 10
+    "rarity": 10,
+    "craftable": true
   },
   {
     "slug": "dummy-amezari-bowgun-g",
     "type": "light-bowgun",
     "name": "dummy (Amezari Bowgun G)",
-    "rarity": 10
+    "rarity": 10,
+    "craftable": true
   },
   {
     "slug": "dark-parasol-g",
     "type": "light-bowgun",
     "name": "Dark Parasol G",
-    "rarity": 10
+    "rarity": 10,
+    "craftable": true
   }
 ]
 }

--- a/content/blacksmith/long-sword/map.json
+++ b/content/blacksmith/long-sword/map.json
@@ -5,6 +5,7 @@
     "type": "long-sword",
     "name": "Bone",
     "rarity": 1,
+    "craftable": true,
     "children": [
       {
         "slug": "large-bone",
@@ -17,6 +18,7 @@
             "type": "long-sword",
             "name": "Bone Katana \"Wolf\"",
             "rarity": 1,
+            "craftable": true,
             "children": [
               {
                 "slug": "bone-katana-shark",
@@ -58,6 +60,7 @@
                         "name": "Fire Dragonsword",
                         "rarity": 5,
                         "element": "dragon",
+                        "craftable": true,
                         "children": [
                           {
                             "slug": "red-dragonsword",
@@ -94,6 +97,7 @@
                     "name": "Wyvern Blade \"Fall\"",
                     "rarity": 3,
                     "element": "fire",
+                    "craftable": true,
                     "children": [
                       {
                         "slug": "wyvern-blade-blood",
@@ -115,6 +119,7 @@
                                 "name": "WyvernBlade\"Silver\"",
                                 "rarity": 9,
                                 "element": "fire",
+                                "craftable": true,
                                 "children": [
                                   {
                                     "slug": "wyvrnbladecamellia",
@@ -137,6 +142,7 @@
                     "name": "Wyvern Blade \"Leaf\"",
                     "rarity": 3,
                     "element": "poison",
+                    "craftable": true,
                     "children": [
                       {
                         "slug": "wyvern-blade-verde",
@@ -158,6 +164,7 @@
                                 "name": "WyvernBlade\"Silver\"",
                                 "rarity": 9,
                                 "element": "fire",
+                                "craftable": true,
                                 "children": [
                                   {
                                     "slug": "wyvrnbladecamellia",
@@ -201,6 +208,7 @@
                         "type": "long-sword",
                         "name": "Lost Black Katana",
                         "rarity": 9,
+                        "craftable": true,
                         "children": [
                           {
                             "slug": "final-black-katana",
@@ -231,6 +239,7 @@
         "type": "long-sword",
         "name": "Bone Katana \"Wolf\"",
         "rarity": 1,
+        "craftable": true,
         "children": [
           {
             "slug": "bone-katana-shark",
@@ -272,6 +281,7 @@
                     "name": "Fire Dragonsword",
                     "rarity": 5,
                     "element": "dragon",
+                    "craftable": true,
                     "children": [
                       {
                         "slug": "red-dragonsword",
@@ -308,6 +318,7 @@
                 "name": "Wyvern Blade \"Fall\"",
                 "rarity": 3,
                 "element": "fire",
+                "craftable": true,
                 "children": [
                   {
                     "slug": "wyvern-blade-blood",
@@ -329,6 +340,7 @@
                             "name": "WyvernBlade\"Silver\"",
                             "rarity": 9,
                             "element": "fire",
+                            "craftable": true,
                             "children": [
                               {
                                 "slug": "wyvrnbladecamellia",
@@ -351,6 +363,7 @@
                 "name": "Wyvern Blade \"Leaf\"",
                 "rarity": 3,
                 "element": "poison",
+                "craftable": true,
                 "children": [
                   {
                     "slug": "wyvern-blade-verde",
@@ -372,6 +385,7 @@
                             "name": "WyvernBlade\"Silver\"",
                             "rarity": 9,
                             "element": "fire",
+                            "craftable": true,
                             "children": [
                               {
                                 "slug": "wyvrnbladecamellia",
@@ -399,12 +413,14 @@
     "type": "great-sword",
     "name": "Buster Sword+",
     "rarity": 1,
+    "craftable": true,
     "children": [
       {
         "slug": "iron-katana",
         "type": "long-sword",
         "name": "Iron Katana",
         "rarity": 1,
+        "craftable": true,
         "children": [
           {
             "slug": "iron-katana-grace",
@@ -467,6 +483,7 @@
                     "name": "Saber",
                     "rarity": 5,
                     "element": "fire",
+                    "craftable": true,
                     "children": [
                       {
                         "slug": "lion-dance-saber",
@@ -500,6 +517,7 @@
                     "type": "long-sword",
                     "name": "Mirage Finsword",
                     "rarity": 5,
+                    "craftable": true,
                     "children": [
                       {
                         "slug": "mirage-finsword-plus",
@@ -524,12 +542,14 @@
                 "type": "long-sword",
                 "name": "Dark Scythe",
                 "rarity": 3,
+                "craftable": true,
                 "children": [
                   {
                     "slug": "tormentor",
                     "type": "long-sword",
                     "name": "Tormentor",
                     "rarity": 4,
+                    "craftable": true,
                     "children": [
                       {
                         "slug": "scythe-of-menace",
@@ -552,6 +572,7 @@
                         "type": "long-sword",
                         "name": "Crab Cutter",
                         "rarity": 6,
+                        "craftable": true,
                         "children": [
                           {
                             "slug": "daimyo-cutter",
@@ -592,6 +613,7 @@
                                 "type": "great-sword",
                                 "name": "Violet Pincer",
                                 "rarity": 9,
+                                "craftable": true,
                                 "children": []
                               }
                             ]
@@ -663,6 +685,7 @@
     "type": "great-sword",
     "name": "Buster Sword",
     "rarity": 1,
+    "craftable": true,
     "children": [
       {
         "slug": "blango-destroyer",
@@ -670,6 +693,7 @@
         "name": "Blango Destroyer",
         "rarity": 2,
         "element": "ice",
+        "craftable": true,
         "children": [
           {
             "slug": "blango-destroyer-plus",
@@ -727,6 +751,7 @@
         "type": "long-sword",
         "name": "Crab Cutter",
         "rarity": 6,
+        "craftable": true,
         "children": [
           {
             "slug": "daimyo-cutter",
@@ -767,6 +792,7 @@
                 "type": "great-sword",
                 "name": "Violet Pincer",
                 "rarity": 9,
+                "craftable": true,
                 "children": []
               }
             ]
@@ -788,6 +814,7 @@
         "name": "Icesteel Blade",
         "rarity": 8,
         "element": "ice",
+        "craftable": true,
         "children": [
           {
             "slug": "daora-s-raid",
@@ -805,6 +832,7 @@
     "type": "long-sword",
     "name": "Tigrex Tooth",
     "rarity": 5,
+    "craftable": true,
     "children": [
       {
         "slug": "tigrex-katana",
@@ -825,12 +853,14 @@
         "type": "long-sword",
         "name": "Hidden Saber",
         "rarity": 7,
+        "craftable": true,
         "children": [
           {
             "slug": "shadow-of-the-moon",
             "type": "long-sword",
             "name": "Shadow of the Moon",
-            "rarity": 10
+            "rarity": 10,
+            "craftable": true
           }
         ]
       }
@@ -842,6 +872,7 @@
     "name": "Dragonwood L.Sword",
     "rarity": 5,
     "element": "paralysis",
+    "craftable": true,
     "children": [
       {
         "slug": "fanatic-dragonwd-ls",
@@ -856,6 +887,7 @@
             "name": "AncientDragonwoodLS",
             "rarity": 9,
             "element": "paralysis",
+            "craftable": true,
             "children": [
               {
                 "slug": "ancientslayrdrgnwdls",
@@ -876,6 +908,7 @@
     "name": "Black Scythe",
     "rarity": 5,
     "element": "dragon",
+    "craftable": true,
     "children": [
       {
         "slug": "fatalis-sickle",
@@ -901,6 +934,7 @@
     "name": "Centenarian Dagger",
     "rarity": 5,
     "element": "fire",
+    "craftable": true,
     "children": [
       {
         "slug": "susano-blade",
@@ -938,6 +972,7 @@
     "type": "great-sword",
     "name": "Agito",
     "rarity": 6,
+    "craftable": true,
     "children": [
       {
         "slug": "rusty-claymore",
@@ -983,6 +1018,7 @@
         "name": "Demon Halberd",
         "rarity": 7,
         "element": "thunder",
+        "craftable": true,
         "children": [
           {
             "slug": "great-demon-halberd",
@@ -1009,12 +1045,14 @@
     "type": "great-sword",
     "name": "Carbalite Sword",
     "rarity": 6,
+    "craftable": true,
     "children": [
       {
         "slug": "guardian-sword",
         "type": "long-sword",
         "name": "Guardian Sword",
         "rarity": 6,
+        "craftable": true,
         "children": [
           {
             "slug": "imperial-sword",
@@ -1028,6 +1066,7 @@
                 "name": "Aqua Guardian",
                 "rarity": 9,
                 "element": "water",
+                "craftable": true,
                 "children": [
                   {
                     "slug": "atlantica",
@@ -1065,6 +1104,7 @@
     "type": "long-sword",
     "name": "Great Hornfly Saber",
     "rarity": 6,
+    "craftable": true,
     "children": [
       {
         "slug": "exceptnlhornflysaber",
@@ -1080,6 +1120,7 @@
     "name": "dummy (LS Fan \"Gavas\")",
     "rarity": 6,
     "element": "ice",
+    "craftable": true,
     "children": [
       {
         "slug": "dummy-ls-fan-10k-gavas",
@@ -1119,6 +1160,7 @@
     "type": "long-sword",
     "name": "Akantor Katana",
     "rarity": 8,
+    "craftable": true,
     "children": [
       {
         "slug": "akantor-broadswrd-s",
@@ -1134,6 +1176,7 @@
     "name": "Igneous Blade",
     "rarity": 9,
     "element": "fire",
+    "craftable": true,
     "children": [
       {
         "slug": "liquid-fire-blade",
@@ -1141,6 +1184,7 @@
         "name": "Liquid Fire Blade",
         "rarity": 9,
         "element": "fire",
+        "craftable": true,
         "children": [
           {
             "slug": "divine-fire-blade",
@@ -1158,6 +1202,7 @@
     "type": "great-sword",
     "name": "Decider",
     "rarity": 9,
+    "craftable": true,
     "children": [
       {
         "slug": "liquid-fire-blade",
@@ -1165,6 +1210,7 @@
         "name": "Liquid Fire Blade",
         "rarity": 9,
         "element": "fire",
+        "craftable": true,
         "children": [
           {
             "slug": "divine-fire-blade",
@@ -1182,139 +1228,160 @@
     "type": "long-sword",
     "name": "dummy (Amezari Blade)",
     "rarity": 9,
-    "element": "water"
+    "element": "water",
+    "craftable": true
   },
   {
     "slug": "dummy-pirate-sword-j",
     "type": "long-sword",
     "name": "dummy (Pirate Sword J)",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "ukanlos-slicer",
     "type": "long-sword",
     "name": "Ukanlos Slicer",
     "rarity": 10,
-    "element": "ice"
+    "element": "ice",
+    "craftable": true
   },
   {
     "slug": "bone-g",
     "type": "long-sword",
     "name": "Bone G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "iron-katana-g",
     "type": "long-sword",
     "name": "Iron Katana G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "bonekatandragon-g",
     "type": "long-sword",
     "name": "BoneKatan\"Dragon\" G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "eager-cleaver-g",
     "type": "long-sword",
     "name": "Eager Cleaver G",
     "rarity": 9,
-    "element": "thunder"
+    "element": "thunder",
+    "craftable": true
   },
   {
     "slug": "black-katana-g",
     "type": "long-sword",
     "name": "Black Katana G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "blango-destroyer-g",
     "type": "long-sword",
     "name": "Blango Destroyer G",
     "rarity": 9,
-    "element": "ice"
+    "element": "ice",
+    "craftable": true
   },
   {
     "slug": "tormentor-g",
     "type": "long-sword",
     "name": "Tormentor G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "crimson-scythe-g",
     "type": "long-sword",
     "name": "Crimson Scythe G",
     "rarity": 9,
-    "element": "fire"
+    "element": "fire",
+    "craftable": true
   },
   {
     "slug": "frost-ripper-g",
     "type": "long-sword",
     "name": "Frost Ripper G",
     "rarity": 9,
-    "element": "water"
+    "element": "water",
+    "craftable": true
   },
   {
     "slug": "imperial-sword-g",
     "type": "long-sword",
     "name": "Imperial Sword G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "daimyo-cutter-g",
     "type": "long-sword",
     "name": "Daimyo Cutter G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "blango-destructor-g",
     "type": "long-sword",
     "name": "Blango Destructor G",
     "rarity": 9,
-    "element": "ice"
+    "element": "ice",
+    "craftable": true
   },
   {
     "slug": "wyvernblademapleg",
     "type": "long-sword",
     "name": "WyvernBlade\"Maple\"G",
     "rarity": 10,
-    "element": "fire"
+    "element": "fire",
+    "craftable": true
   },
   {
     "slug": "wyvernbladehollyg",
     "type": "long-sword",
     "name": "WyvernBlade\"Holly\"G",
     "rarity": 10,
-    "element": "poison"
+    "element": "poison",
+    "craftable": true
   },
   {
     "slug": "fanaticdragonwdls-g",
     "type": "long-sword",
     "name": "FanaticDragonwdLS G",
     "rarity": 10,
-    "element": "paralysis"
+    "element": "paralysis",
+    "craftable": true
   },
   {
     "slug": "saber-g",
     "type": "long-sword",
     "name": "Saber G",
     "rarity": 10,
-    "element": "fire"
+    "element": "fire",
+    "craftable": true
   },
   {
     "slug": "susano-blade-g",
     "type": "long-sword",
     "name": "Susano Blade G",
     "rarity": 10,
-    "element": "fire"
+    "element": "fire",
+    "craftable": true
   },
   {
     "slug": "red-dragonsword-g",
     "type": "long-sword",
     "name": "Red Dragonsword G",
     "rarity": 10,
-    "element": "dragon"
+    "element": "dragon",
+    "craftable": true
   }
 ]
 }

--- a/content/blacksmith/sword-and-shield/map.json
+++ b/content/blacksmith/sword-and-shield/map.json
@@ -5,12 +5,14 @@
     "type": "sword-and-shield",
     "name": "Hunter's Dagger",
     "rarity": 1,
+    "craftable": true,
     "children": [
       {
         "slug": "hunter-s-dagger-plus",
         "type": "sword-and-shield",
         "name": "Hunter's Dagger+",
         "rarity": 1,
+        "craftable": true,
         "children": [
           {
             "slug": "assassin-s-dagger",
@@ -23,12 +25,14 @@
                 "type": "sword-and-shield",
                 "name": "Velocidrome Bite",
                 "rarity": 2,
+                "craftable": true,
                 "children": [
                   {
                     "slug": "velocidrome-bite-plus",
                     "type": "sword-and-shield",
                     "name": "Velocidrome Bite+",
                     "rarity": 2,
+                    "craftable": true,
                     "children": [
                       {
                         "slug": "dos-fang-dagger",
@@ -41,6 +45,7 @@
                         "type": "sword-and-shield",
                         "name": "Odyssey",
                         "rarity": 6,
+                        "craftable": true,
                         "children": [
                           {
                             "slug": "odyssey-plus",
@@ -68,6 +73,7 @@
                                     "type": "sword-and-shield",
                                     "name": "Heavy Bang",
                                     "rarity": 9,
+                                    "craftable": true,
                                     "children": [
                                       {
                                         "slug": "master-bang",
@@ -83,6 +89,7 @@
                                     "name": "Thunderblade Vajra",
                                     "rarity": 9,
                                     "element": "thunder",
+                                    "craftable": true,
                                     "children": [
                                       {
                                         "slug": "thunderblade-vajra-plus",
@@ -116,6 +123,7 @@
                             "type": "dual-blades",
                             "name": "Hurricane",
                             "rarity": 6,
+                            "craftable": true,
                             "children": []
                           },
                           {
@@ -124,6 +132,7 @@
                             "name": "Prototype Saw-Slicer",
                             "rarity": 6,
                             "element": "thunder",
+                            "craftable": true,
                             "children": []
                           }
                         ]
@@ -135,6 +144,7 @@
                     "type": "sword-and-shield",
                     "name": "Raven Blade",
                     "rarity": 5,
+                    "craftable": true,
                     "children": [
                       {
                         "slug": "wolf-blade",
@@ -213,6 +223,7 @@
                         "name": "Dual Battleaxe",
                         "rarity": 6,
                         "element": "poison",
+                        "craftable": true,
                         "children": []
                       }
                     ]
@@ -224,6 +235,7 @@
                 "type": "sword-and-shield",
                 "name": "Kitchen Knife",
                 "rarity": 2,
+                "craftable": true,
                 "children": [
                   {
                     "slug": "iron-chefblade",
@@ -249,6 +261,7 @@
             "name": "Frost Edge",
             "rarity": 2,
             "element": "ice",
+            "craftable": true,
             "children": [
               {
                 "slug": "frost-edge-plus",
@@ -279,6 +292,7 @@
                     "name": "Freezing Daggers",
                     "rarity": 4,
                     "element": "ice",
+                    "craftable": true,
                     "children": []
                   }
                 ]
@@ -290,6 +304,7 @@
             "type": "dual-blades",
             "name": "Twin Dagger",
             "rarity": 1,
+            "craftable": true,
             "children": []
           }
         ]
@@ -299,6 +314,7 @@
         "type": "sword-and-shield",
         "name": "Snake Bite",
         "rarity": 1,
+        "craftable": true,
         "children": [
           {
             "slug": "snake-bite-plus",
@@ -328,6 +344,7 @@
                 "name": "Hydra Bite",
                 "rarity": 3,
                 "element": "poison",
+                "craftable": true,
                 "children": [
                   {
                     "slug": "deadly-poison",
@@ -363,6 +380,7 @@
                                     "name": "Queen's Rose",
                                     "rarity": 9,
                                     "element": "poison",
+                                    "craftable": true,
                                     "children": [
                                       {
                                         "slug": "royal-rose",
@@ -401,6 +419,7 @@
         "name": "Giaprey Claws",
         "rarity": 2,
         "element": "ice",
+        "craftable": true,
         "children": []
       }
     ]
@@ -410,6 +429,7 @@
     "type": "sword-and-shield",
     "name": "Bone Kris",
     "rarity": 1,
+    "craftable": true,
     "children": [
       {
         "slug": "bone-kris-plus",
@@ -422,12 +442,14 @@
             "type": "sword-and-shield",
             "name": "Chief Kris",
             "rarity": 1,
+            "craftable": true,
             "children": [
               {
                 "slug": "crimson-club",
                 "type": "sword-and-shield",
                 "name": "Crimson Club",
                 "rarity": 2,
+                "craftable": true,
                 "children": [
                   {
                     "slug": "monoblos-club",
@@ -440,6 +462,7 @@
                         "type": "sword-and-shield",
                         "name": "Studded Club",
                         "rarity": 4,
+                        "craftable": true,
                         "children": [
                           {
                             "slug": "spiked-bat",
@@ -475,6 +498,7 @@
                             "type": "sword-and-shield",
                             "name": "Osteon Pick",
                             "rarity": 6,
+                            "craftable": true,
                             "children": [
                               {
                                 "slug": "osteon-pick-plus",
@@ -496,6 +520,7 @@
                                     "name": "Rajang Club",
                                     "rarity": 7,
                                     "element": "thunder",
+                                    "craftable": true,
                                     "children": [
                                       {
                                         "slug": "taboo-rajang-club",
@@ -520,6 +545,7 @@
                                     "type": "sword-and-shield",
                                     "name": "Binding Blade",
                                     "rarity": 9,
+                                    "craftable": true,
                                     "children": [
                                       {
                                         "slug": "binding-blade-plus",
@@ -545,6 +571,7 @@
                                 "name": "Feather Knife",
                                 "rarity": 6,
                                 "element": "sleep",
+                                "craftable": true,
                                 "children": [
                                   {
                                     "slug": "feather-sword",
@@ -552,6 +579,7 @@
                                     "name": "Feather Sword",
                                     "rarity": 9,
                                     "element": "sleep",
+                                    "craftable": true,
                                     "children": [
                                       {
                                         "slug": "hi-feather-sword",
@@ -574,6 +602,7 @@
                         "name": "Kirin Bolt",
                         "rarity": 5,
                         "element": "thunder",
+                        "craftable": true,
                         "children": [
                           {
                             "slug": "kirin-bolt-plus",
@@ -654,6 +683,7 @@
                 "name": "Red Saber",
                 "rarity": 3,
                 "element": "fire",
+                "craftable": true,
                 "children": [
                   {
                     "slug": "djinn",
@@ -747,6 +777,7 @@
             "type": "dual-blades",
             "name": "Bone Scythe",
             "rarity": 1,
+            "craftable": true,
             "children": []
           }
         ]
@@ -758,6 +789,7 @@
     "type": "sword-and-shield",
     "name": "Rusted Sword",
     "rarity": 1,
+    "craftable": true,
     "children": [
       {
         "slug": "tarnished-sword",
@@ -808,6 +840,7 @@
                     "name": "Twin Nails",
                     "rarity": 5,
                     "element": "ice",
+                    "craftable": true,
                     "children": []
                   }
                 ]
@@ -824,6 +857,7 @@
     "name": "Catspaw",
     "rarity": 2,
     "element": "paralysis",
+    "craftable": true,
     "children": [
       {
         "slug": "catburglar",
@@ -852,6 +886,7 @@
             "name": "Shaka Poison Bite",
             "rarity": 4,
             "element": "poison",
+            "craftable": true,
             "children": [
               {
                 "slug": "shakalaka-saber",
@@ -889,6 +924,7 @@
     "type": "sword-and-shield",
     "name": "Hero's Blade Replica",
     "rarity": 4,
+    "craftable": true,
     "children": [
       {
         "slug": "master-s-replica",
@@ -909,6 +945,7 @@
     "type": "sword-and-shield",
     "name": "Rusted Replica",
     "rarity": 4,
+    "craftable": true,
     "children": [
       {
         "slug": "eternal-replica",
@@ -924,6 +961,7 @@
     "type": "sword-and-shield",
     "name": "Black Belt Sword",
     "rarity": 4,
+    "craftable": true,
     "children": [
       {
         "slug": "expert-sword",
@@ -955,6 +993,7 @@
         "type": "sword-and-shield",
         "name": "Ninja Sword",
         "rarity": 5,
+        "craftable": true,
         "children": [
           {
             "slug": "hi-ninja-sword",
@@ -972,6 +1011,7 @@
     "name": "Flaming Pair",
     "rarity": 5,
     "element": "dragon",
+    "craftable": true,
     "children": [
       {
         "slug": "blue-ogre-sword",
@@ -979,6 +1019,7 @@
         "name": "Blue Ogre Sword",
         "rarity": 8,
         "element": "dragon",
+        "craftable": true,
         "children": [
           {
             "slug": "azure-ogre-sword",
@@ -1012,6 +1053,7 @@
         "name": "Dual Carapace",
         "rarity": 7,
         "element": "water",
+        "craftable": true,
         "children": [
           {
             "slug": "dual-carapace-plus",
@@ -1053,6 +1095,7 @@
     "name": "Black Sword",
     "rarity": 5,
     "element": "dragon",
+    "craftable": true,
     "children": [
       {
         "slug": "double-dragon",
@@ -1101,6 +1144,7 @@
     "type": "sword-and-shield",
     "name": "Rex Talon",
     "rarity": 5,
+    "craftable": true,
     "children": [
       {
         "slug": "tigrex-sword",
@@ -1121,12 +1165,14 @@
         "type": "sword-and-shield",
         "name": "Hidden Edge",
         "rarity": 7,
+        "craftable": true,
         "children": [
           {
             "slug": "midnight-blades",
             "type": "sword-and-shield",
             "name": "Midnight Blades",
-            "rarity": 10
+            "rarity": 10,
+            "craftable": true
           }
         ]
       }
@@ -1161,253 +1207,291 @@
     "slug": "shining-wyvern-blade",
     "type": "sword-and-shield",
     "name": "Shining Wyvern Blade",
-    "rarity": 8
+    "rarity": 8,
+    "craftable": true
   },
   {
     "slug": "ms-m-h-puppet",
     "type": "sword-and-shield",
     "name": "Ms. M.H. Puppet",
     "rarity": 9,
-    "element": "paralysis"
+    "element": "paralysis",
+    "craftable": true
   },
   {
     "slug": "ukanlos-soul-hatchet",
     "type": "sword-and-shield",
     "name": "Ukanlos Soul Hatchet",
     "rarity": 10,
-    "element": "ice"
+    "element": "ice",
+    "craftable": true
   },
   {
     "slug": "hunter-s-dagger-g",
     "type": "sword-and-shield",
     "name": "Hunter's Dagger G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "chief-kris-g",
     "type": "sword-and-shield",
     "name": "Chief Kris G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "tarnished-sword-g",
     "type": "sword-and-shield",
     "name": "Tarnished Sword G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "snake-bite-g",
     "type": "sword-and-shield",
     "name": "Snake Bite G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "deathprize-g",
     "type": "sword-and-shield",
     "name": "Deathprize G",
     "rarity": 9,
-    "element": "paralysis"
+    "element": "paralysis",
+    "craftable": true
   },
   {
     "slug": "deadly-poison-g",
     "type": "sword-and-shield",
     "name": "Deadly Poison G",
     "rarity": 9,
-    "element": "poison"
+    "element": "poison",
+    "craftable": true
   },
   {
     "slug": "velocidrome-bite-g",
     "type": "sword-and-shield",
     "name": "Velocidrome Bite G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "poison-battleaxe-g",
     "type": "sword-and-shield",
     "name": "Poison Battleaxe G",
     "rarity": 9,
-    "element": "poison"
+    "element": "poison",
+    "craftable": true
   },
   {
     "slug": "thunderbane-g",
     "type": "sword-and-shield",
     "name": "Thunderbane G",
     "rarity": 9,
-    "element": "thunder"
+    "element": "thunder",
+    "craftable": true
   },
   {
     "slug": "sandman-finsword-g",
     "type": "sword-and-shield",
     "name": "Sandman Finsword G",
     "rarity": 9,
-    "element": "sleep"
+    "element": "sleep",
+    "craftable": true
   },
   {
     "slug": "monoblos-club-g",
     "type": "sword-and-shield",
     "name": "Monoblos Club G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "spiked-bat-g",
     "type": "sword-and-shield",
     "name": "Spiked Bat G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "kirin-bolt-g",
     "type": "sword-and-shield",
     "name": "Kirin Bolt G",
     "rarity": 9,
-    "element": "thunder"
+    "element": "thunder",
+    "craftable": true
   },
   {
     "slug": "kirin-bolt-plus-g",
     "type": "sword-and-shield",
     "name": "Kirin Bolt+ G",
     "rarity": 9,
-    "element": "thunder"
+    "element": "thunder",
+    "craftable": true
   },
   {
     "slug": "kirin-bolt-indora-g",
     "type": "sword-and-shield",
     "name": "Kirin Bolt Indora G",
     "rarity": 9,
-    "element": "thunder"
+    "element": "thunder",
+    "craftable": true
   },
   {
     "slug": "djinn-g",
     "type": "sword-and-shield",
     "name": "Djinn G",
     "rarity": 9,
-    "element": "fire"
+    "element": "fire",
+    "craftable": true
   },
   {
     "slug": "catburglar-g",
     "type": "sword-and-shield",
     "name": "Catburglar G",
     "rarity": 9,
-    "element": "paralysis"
+    "element": "paralysis",
+    "craftable": true
   },
   {
     "slug": "eternal-strife-g",
     "type": "sword-and-shield",
     "name": "Eternal Strife G",
     "rarity": 9,
-    "element": "dragon"
+    "element": "dragon",
+    "craftable": true
   },
   {
     "slug": "odyssey-g",
     "type": "sword-and-shield",
     "name": "Odyssey G",
     "rarity": 9,
-    "element": "water"
+    "element": "water",
+    "craftable": true
   },
   {
     "slug": "osteon-pick-g",
     "type": "sword-and-shield",
     "name": "Osteon Pick G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "serpent-bite-g",
     "type": "sword-and-shield",
     "name": "Serpent Bite G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "millennium-knife-g",
     "type": "sword-and-shield",
     "name": "Millennium Knife G",
-    "rarity": 9
+    "rarity": 9,
+    "craftable": true
   },
   {
     "slug": "hi-frost-edge-g",
     "type": "sword-and-shield",
     "name": "Hi Frost Edge G",
     "rarity": 9,
-    "element": "ice"
+    "element": "ice",
+    "craftable": true
   },
   {
     "slug": "deadly-battleaxe-g",
     "type": "sword-and-shield",
     "name": "Deadly Battleaxe G",
     "rarity": 9,
-    "element": "poison"
+    "element": "poison",
+    "craftable": true
   },
   {
     "slug": "high-sandman-spike-g",
     "type": "sword-and-shield",
     "name": "High Sandman Spike G",
     "rarity": 9,
-    "element": "sleep"
+    "element": "sleep",
+    "craftable": true
   },
   {
     "slug": "blazing-falchion-g",
     "type": "sword-and-shield",
     "name": "Blazing Falchion G",
     "rarity": 10,
-    "element": "fire"
+    "element": "fire",
+    "craftable": true
   },
   {
     "slug": "corona-g",
     "type": "sword-and-shield",
     "name": "Corona G",
     "rarity": 10,
-    "element": "fire"
+    "element": "fire",
+    "craftable": true
   },
   {
     "slug": "queen-rapier-g",
     "type": "sword-and-shield",
     "name": "Queen Rapier G",
     "rarity": 10,
-    "element": "poison"
+    "element": "poison",
+    "craftable": true
   },
   {
     "slug": "hi-ninja-sword-g",
     "type": "sword-and-shield",
     "name": "Hi Ninja Sword G",
-    "rarity": 10
+    "rarity": 10,
+    "craftable": true
   },
   {
     "slug": "thor-s-dagger-g",
     "type": "sword-and-shield",
     "name": "Thor's Dagger G",
     "rarity": 10,
-    "element": "thunder"
+    "element": "thunder",
+    "craftable": true
   },
   {
     "slug": "melynx-tool-g",
     "type": "sword-and-shield",
     "name": "Melynx Tool G",
     "rarity": 10,
-    "element": "paralysis"
+    "element": "paralysis",
+    "craftable": true
   },
   {
     "slug": "shakalaka-saber-g",
     "type": "sword-and-shield",
     "name": "Shakalaka Saber G",
     "rarity": 10,
-    "element": "poison"
+    "element": "poison",
+    "craftable": true
   },
   {
     "slug": "master-s-blade-g",
     "type": "sword-and-shield",
     "name": "Master's Blade G",
-    "rarity": 10
+    "rarity": 10,
+    "craftable": true
   },
   {
     "slug": "eternal-treasure-g",
     "type": "sword-and-shield",
     "name": "Eternal Treasure G",
     "rarity": 10,
-    "element": "dragon"
+    "element": "dragon",
+    "craftable": true
   },
   {
     "slug": "shiningwyvernblade-g",
     "type": "sword-and-shield",
     "name": "ShiningWyvernBlade G",
-    "rarity": 10
+    "rarity": 10,
+    "craftable": true
   }
 ]
 }

--- a/sass/_components.scss
+++ b/sass/_components.scss
@@ -297,6 +297,16 @@ $ranks: (
     width: 16px;
     height: 16px;
   }
+
+  &--craftable {
+    margin-right: 0px;
+    position: absolute;
+    top: 0px;
+    left: -8px;
+    rotate: 45deg;
+    z-index: 100;
+  }
+  
   &--large,
   &--large img {
     width: 52px;

--- a/sass/_components.scss
+++ b/sass/_components.scss
@@ -289,6 +289,14 @@ $ranks: (
     image-rendering: pixelated;
   }
 
+  &--small {
+    width: 16px;
+    height: 16px;
+  }
+  &--small img {
+    width: 16px;
+    height: 16px;
+  }
   &--large,
   &--large img {
     width: 52px;

--- a/scripts/generate-maps.rb
+++ b/scripts/generate-maps.rb
@@ -42,6 +42,10 @@ def push_weapon(weapon, parent_weapon = nil, array, weapons_data, sibling_weapon
     array.last[:element] = weapon["elements"][0]["name"].downcase
   end
 
+  if weapon.key?("create_cost") and weapon["create_cost"]
+    array.last[:craftable] = true
+  end
+
   if weapon.key?("improve_to") and weapon["improve_to"]
     array.last[:children] = []
 

--- a/templates/macros.html
+++ b/templates/macros.html
@@ -19,6 +19,13 @@
     href="{{ section.path }}{{ weapon.slug }}/"
     {% endif %}
   >
+    {% if weapon.craftable %}
+      <div  title="Craftable" class="icon icon--mini icon--small icon--hammer icon--rarity-6 icon--craftable">
+        <img src="/images/scroll-short.png" alt="craftable-background" style="position: absolute;z-index: 90;transform: rotate(-45deg);">
+        <img src="/images/hammer-mini.png" alt="craftable", style="z-index: 95;">
+      </div>
+    {% endif %}
+
     {% if weapon.rarity %}
       <div class="
         icon


### PR DESCRIPTION
Hello,

I've added a small icon on top of weapons that can be crafted in the weapon tree.

I took inspiration from World, Rise and Wilds. But I kept the MHFU icons and crafted a nifty little "craftable" icon.

Screenshot:
<img width="644" height="725" alt="mhfu_weapon_craftable" src="https://github.com/user-attachments/assets/76883814-c66c-4df7-b4cc-3f532d360b3c" />

Not fan of how I did it in the `.html` file, if you think of a better way, don't hesitate to tweak the code.