### PR TITLE
fix: Missing trailing parenthesis in sources for monsters

### DIFF
--- a/data/monsters/bird-wyvern.json
+++ b/data/monsters/bird-wyvern.json
@@ -797,6 +797,10 @@
             {
               "name": "Kut-Ku Scale x1",
               "chance": "75%"
+            },
+            {
+              "name": "Kut-Ku Scale x3",
+              "chance": "25%"
             }
           ],
           "shiny drop : sonic, doesn't work when rage": [

--- a/data/monsters/elder-dragon.json
+++ b/data/monsters/elder-dragon.json
@@ -1117,6 +1117,10 @@
             {
               "name": "HardTeostraHorn x1",
               "chance": "80%"
+            },
+            {
+              "name": "Teostra Horn+ x1",
+              "chance": "20%"
             }
           ],
           "break wings": [

--- a/sources/monsters/bird_wyvern/yian_kut-ku.txt
+++ b/sources/monsters/bird_wyvern/yian_kut-ku.txt
@@ -8,7 +8,7 @@
 
 2. Break Ears
 -  Kut-Ku Scale x1 (75%)
--  Kut-Ku Scale x3 (25%
+-  Kut-Ku Scale x3 (25%)
 
 3. Shiny Drop : sonic, doesn't work when rage
 -  Wyvern Tears (75%)

--- a/sources/monsters/elder_dragon/teostra.txt
+++ b/sources/monsters/elder_dragon/teostra.txt
@@ -88,7 +88,7 @@
         
 3. Break Horn
 - HardTeostraHorn x1 (80%)
-- Teostra Horn+ x1 (20%
+- Teostra Horn+ x1 (20%)
 
 4. Break Wings
 - Fire Dragon Pwdr x1 (30%)


### PR DESCRIPTION
- Kut-Ku
- Teostra